### PR TITLE
Add landsat_scaling function

### DIFF
--- a/geemap/conversion.py
+++ b/geemap/conversion.py
@@ -275,7 +275,12 @@ def check_map_functions(input_lines):
 
 
 def js_to_python(
-    in_file, out_file=None, use_qgis=True, github_repo=None, show_map=True, import_geemap=False
+    in_file,
+    out_file=None,
+    use_qgis=True,
+    github_repo=None,
+    show_map=True,
+    import_geemap=False,
 ):
     """Converts an Earth Engine JavaScript to Python script.
 
@@ -532,7 +537,13 @@ def js_snippet_to_py(
     try:
         with open(in_js, "w") as f:
             f.write(in_js_snippet)
-        js_to_python(in_js, out_file=out_py, use_qgis=False, show_map=show_map, import_geemap=import_geemap)
+        js_to_python(
+            in_js,
+            out_file=out_py,
+            use_qgis=False,
+            show_map=show_map,
+            import_geemap=import_geemap,
+        )
 
         out_lines = []
         if import_ee:

--- a/geemap/examples/__init__.py
+++ b/geemap/examples/__init__.py
@@ -4,7 +4,9 @@ import pkg_resources
 
 _pkg_dir = os.path.dirname(pkg_resources.resource_filename("geemap", "geemap.py"))
 _datasets_path = os.path.join(_pkg_dir, "examples/datasets.txt")
-_baseurl = "https://raw.githubusercontent.com/gee-community/geemap/master/examples/data/"
+_baseurl = (
+    "https://raw.githubusercontent.com/gee-community/geemap/master/examples/data/"
+)
 
 with open(_datasets_path) as f:
     _names = [line.strip() for line in f.readlines()]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ ipytree
 matplotlib
 numpy
 pandas
+plotly
 pyperclip
 python-box
 scooby

--- a/requirements_extra.txt
+++ b/requirements_extra.txt
@@ -4,7 +4,6 @@ gdown
 geeadd>=0.5.1
 geojson
 geopandas
-plotly
 pycrs
 pyshp>=2.1.3
 sankee>=0.1.0


### PR DESCRIPTION
This PR adds the `landsat_scaling function. 

Example:

```python
import ee
import geemap

Map = geemap.Map()
point = ee.Geometry.Point([ -122.444687, 37.753344])
image = ee.ImageCollection('LANDSAT/LC09/C02/T1_L2') \
    .filterBounds(point) \
    .sort('CLOUD_COVER') \
    .first()
result = geemap.landsat_scaling(image, apply_fmask=False)
vis_params = {'min': 0, 'max': 0.3, 'bands': ['SR_B5', 'SR_B4', 'SR_B3']}
Map.addLayer(result, vis_params, 'Landsat 8 TOA')
Map.centerObject(image)
Map
```