### PR TITLE
Make the Inspector customizable

### DIFF
--- a/geemap/toolbar.py
+++ b/geemap/toolbar.py
@@ -4616,11 +4616,15 @@ def search_data_gui(m):
     m.add(data_control)
 
 
-def ee_inspector_gui(m, position="topright", opened=True):
+def ee_inspector_gui(m, names=None, visible=True, position="topright", opened=True):
     """Earth Engine Inspector GUI.
 
     Args:
         m (geemap.Map): The geemap.Map object.
+        names (str | list, optional): The names of the layers to be included. Defaults to None.
+        visible (bool, optional): Whether to inspect visible layers only. Defaults to True.
+        position (str, optional): The position of the control. Defaults to "topright".
+        opened (bool, optional): Whether the control is opened. Defaults to True.
 
     """
     from ipytree import Tree
@@ -4728,10 +4732,10 @@ def ee_inspector_gui(m, position="topright", opened=True):
                 nodes = []
                 point_node = m._point_info(latlon, return_node=True)
                 nodes.append(point_node)
-                pixels_node = m._pixels_info(latlon, return_node=True)
+                pixels_node = m._pixels_info(latlon, names, visible, return_node=True)
                 if pixels_node.nodes:
                     nodes.append(pixels_node)
-                objects_node = m._objects_info(latlon, return_node=True)
+                objects_node = m._objects_info(latlon, names, visible, return_node=True)
                 if objects_node.nodes:
                     nodes.append(objects_node)
                 tree.nodes = nodes


### PR DESCRIPTION
This PR makes the Inspector GUI customizable. Users can specify  layer `names` to be used for the Inspector