### PR TITLE
feat: adding typehinting function parameter for better clarity

### DIFF
--- a/geemap/report.py
+++ b/geemap/report.py
@@ -1,8 +1,15 @@
 import scooby
+from typing import Optional
 
 
 class Report(scooby.Report):
-    def __init__(self, additional=None, ncol=3, text_width=80, sort=False):
+    def __init__(
+        self,
+        additional: Optional[dict] = None,
+        ncol: int = 3,
+        text_width: int = 80,
+        sort: bool = False,
+    ):
         """Initiate a scooby.Report instance."""
         core = [
             "geemap",

--- a/geemap/timelapse.py
+++ b/geemap/timelapse.py
@@ -1,6 +1,7 @@
 """Module for creating timelapse from various Earth Engine ImageCollection.
 """
 import datetime
+import glob
 import io
 import os
 import shutil
@@ -8,11 +9,18 @@ import shutil
 import ee
 
 from .common import *
+from PIL import Image
+from typing import Union, List
 
 
 def add_overlay(
-    collection, overlay_data, color="black", width=1, opacity=1.0, region=None
-):
+    collection: ee.ImageCollection,
+    overlay_data: Union[str, ee.geometry, ee.ee.FeatureCollection],
+    color: str = "black",
+    width: int = 1,
+    opacity: float = 1.0,
+    region: Union[ee.Geometry, ee.FeatureCollection] = None,
+) -> ee.ImageCollection:
     """Adds an overlay to an image collection.
 
     Args:
@@ -84,7 +92,15 @@ def add_overlay(
         raise Exception(e)
 
 
-def make_gif(images, out_gif, ext="jpg", fps=10, loop=0, mp4=False, clean_up=False):
+def make_gif(
+    images: Union[List[str], str],
+    out_gif: str,
+    ext: str = "jpg",
+    fps: int = 10,
+    loop: int = 0,
+    mp4: bool = False,
+    clean_up: bool = False,
+) -> None:
     """Creates a gif from a list of images.
 
     Args:
@@ -96,9 +112,6 @@ def make_gif(images, out_gif, ext="jpg", fps=10, loop=0, mp4=False, clean_up=Fal
         mp4 (bool, optional): Whether to convert the gif to mp4. Defaults to False.
 
     """
-    import glob
-    from PIL import Image
-
     if isinstance(images, str) and os.path.isdir(images):
         images = list(glob.glob(os.path.join(images, f"*.{ext}")))
         if len(images) == 0:

--- a/geemap/timelapse.py
+++ b/geemap/timelapse.py
@@ -15,7 +15,7 @@ from typing import Union, List
 
 def add_overlay(
     collection: ee.ImageCollection,
-    overlay_data: Union[str, ee.geometry, ee.FeatureCollection],
+    overlay_data: Union[str, ee.Geometry, ee.FeatureCollection],
     color: str = "black",
     width: int = 1,
     opacity: float = 1.0,

--- a/geemap/timelapse.py
+++ b/geemap/timelapse.py
@@ -15,7 +15,7 @@ from typing import Union, List
 
 def add_overlay(
     collection: ee.ImageCollection,
-    overlay_data: Union[str, ee.geometry, ee.ee.FeatureCollection],
+    overlay_data: Union[str, ee.geometry, ee.FeatureCollection],
     color: str = "black",
     width: int = 1,
     opacity: float = 1.0,


### PR DESCRIPTION
- adding type hinting on specific function, information about type hinting function [here](https://docs.python.org/3/library/typing.html). (its very good when this stuff applied on all function for code readable from user)


- move imported library into the top of file (information reference from [PEP8](https://peps.python.org/pep-0008/):
  - avoiding from circular imports
  - Moving imports inside the function scope helps ensure a tidy module namespace, preventing them from appearing in tab-completion suggestions.
  - While import statements are very fast on subsequent runs, they still impose a speed penalty that can be significant when the function is simple but frequently used.
  - Refactoring could be simplified by placing the imports within the function where they are used, which makes it easier to move the function to another module. This approach can also enhance readability.