### PR TITLE
Add support for downloading images in parallel

### DIFF
--- a/docs/notebooks/136_download_parallel.ipynb
+++ b/docs/notebooks/136_download_parallel.ipynb
@@ -1,0 +1,93 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://githubtocolab.com/gee-community/geemap/blob/master/examples/notebooks/136_download_parallel.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open in Colab\"/></a>\n",
+    "\n",
+    "**Downloading Earth Engine images in parallel**\n",
+    "\n",
+    "Uncomment the following line to install [geemap](https://geemap.org) if needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !pip install -U geemap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ee\n",
+    "import geemap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Map = geemap.Map(center=[14.9447, -16.6552], zoom=4)\n",
+    "\n",
+    "image = ee.Image('LANDSAT/LE7_TOA_5YEAR/1999_2003').select(['B4', 'B3', 'B2'])\n",
+    "country_list = [\"Gambia\", \"Qatar\", \"Lebanon\", \"Jamaica\"]\n",
+    "fc = ee.FeatureCollection(\"FAO/GAUL/2015/level0\").filter(\n",
+    "    ee.Filter.inList(\"ADM0_NAME\", country_list)\n",
+    ")\n",
+    "style = {'color': 'ffff00ff', 'width': 2, 'lineType': 'solid', 'fillColor': 'ffff0060'}\n",
+    "\n",
+    "Map.addLayer(image, {'min': 20, 'max': 200, 'gamma': 2.0}, 'Landsat')\n",
+    "Map.addLayer(fc.style(**style), {}, 'Countries')\n",
+    "\n",
+    "Map"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geemap.download_ee_image_tiles_parallel(\n",
+    "    image, fc, out_dir='.', scale=100, crs='EPSG:3857', column='ADM0_NAME'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The parallel downloading above takes ~18 seconds. The serial downloading below takes ~44 seconds."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geemap.download_ee_image_tiles(\n",
+    "    image, fc, out_dir='.', scale=100, crs='EPSG:3857', column='ADM0_NAME'\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -147,3 +147,4 @@ More video tutorials for geemap and Earth Engine are available on my [YouTube ch
 133. Developing interactive web apps with gradio and geemap ([notebook](https://geemap.org/notebooks/133_gradio))
 134. Downloading Earth Engine map tiles as a GeoTIFF ([notebook](https://geemap.org/notebooks/134_ee_to_geotiff))
 135. Earth Engine Image Segmentation with the Segment Anything Model ([notebook](https://geemap.org/notebooks/135_segmentation))
+136. Downloading Earth Engine images in parallel ([notebook](https://geemap.org/notebooks/136_download_parallel))

--- a/examples/README.md
+++ b/examples/README.md
@@ -152,6 +152,7 @@ More video tutorials for geemap and Earth Engine are available on my [YouTube ch
 133. Developing interactive web apps with gradio and geemap ([notebook](https://geemap.org/notebooks/133_gradio))
 134. Downloading Earth Engine map tiles as a GeoTIFF ([notebook](https://geemap.org/notebooks/134_ee_to_geotiff))
 135. Earth Engine Image Segmentation with the Segment Anything Model ([notebook](https://geemap.org/notebooks/135_segmentation))
+136. Downloading Earth Engine images in parallel ([notebook](https://geemap.org/notebooks/136_download_parallel))
 
 ### 1. Introducing the geemap Python package for interactive mapping with Google Earth Engine
 

--- a/examples/notebooks/136_download_parallel.ipynb
+++ b/examples/notebooks/136_download_parallel.ipynb
@@ -1,0 +1,93 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://githubtocolab.com/gee-community/geemap/blob/master/examples/notebooks/136_download_parallel.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open in Colab\"/></a>\n",
+    "\n",
+    "**Downloading Earth Engine images in parallel**\n",
+    "\n",
+    "Uncomment the following line to install [geemap](https://geemap.org) if needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !pip install -U geemap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ee\n",
+    "import geemap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Map = geemap.Map(center=[14.9447, -16.6552], zoom=4)\n",
+    "\n",
+    "image = ee.Image('LANDSAT/LE7_TOA_5YEAR/1999_2003').select(['B4', 'B3', 'B2'])\n",
+    "country_list = [\"Gambia\", \"Qatar\", \"Lebanon\", \"Jamaica\"]\n",
+    "fc = ee.FeatureCollection(\"FAO/GAUL/2015/level0\").filter(\n",
+    "    ee.Filter.inList(\"ADM0_NAME\", country_list)\n",
+    ")\n",
+    "style = {'color': 'ffff00ff', 'width': 2, 'lineType': 'solid', 'fillColor': 'ffff0060'}\n",
+    "\n",
+    "Map.addLayer(image, {'min': 20, 'max': 200, 'gamma': 2.0}, 'Landsat')\n",
+    "Map.addLayer(fc.style(**style), {}, 'Countries')\n",
+    "\n",
+    "Map"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geemap.download_ee_image_tiles_parallel(\n",
+    "    image, fc, out_dir='.', scale=100, crs='EPSG:3857', column='ADM0_NAME'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The parallel downloading above takes ~18 seconds. The serial downloading below takes ~44 seconds."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geemap.download_ee_image_tiles(\n",
+    "    image, fc, out_dir='.', scale=100, crs='EPSG:3857', column='ADM0_NAME'\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/geemap/common.py
+++ b/geemap/common.py
@@ -175,7 +175,7 @@ def ee_initialize(
     if "http_transport" not in kwargs:
         kwargs["http_transport"] = httplib2.Http()
 
-    auth_args['auth_mode'] = auth_mode
+    auth_args["auth_mode"] = auth_mode
 
     if ee.data._credentials is None:
         ee_token = os.environ.get(token_name)
@@ -12625,6 +12625,7 @@ def download_ee_image_tiles(
     shape=None,
     scale_offset=False,
     unmask_value=None,
+    column=None,
     **kwargs,
 ):
     """Download an Earth Engine Image as small tiles based on ee.FeatureCollection. Images larger than the `Earth Engine size limit are split and downloaded as
@@ -12658,8 +12659,13 @@ def download_ee_image_tiles(
             Whether to apply any EE band scales and offsets to the image.
         unmask_value (float, optional): The value to use for pixels that are masked in the input image. If the exported image contains zero values,
             you should set the unmask value to a  non-zero value so that the zero values are not treated as missing data. Defaults to None.
+        column (str, optional): The column name to use for the filename. Defaults to None.
 
     """
+    import time
+
+    start = time.time()
+
     if os.environ.get("USE_MKDOCS") is not None:
         return
 
@@ -12678,10 +12684,15 @@ def download_ee_image_tiles(
     count = features.size().getInfo()
     collection = features.toList(count)
 
+    if column is not None:
+        names = features.aggregate_array(column).getInfo()
+    else:
+        names = [str(i + 1).zfill(len(str(count))) for i in range(count)]
+
     for i in range(count):
         region = ee.Feature(collection.get(i)).geometry()
         filename = os.path.join(
-            out_dir, "{}{}.tif".format(prefix, str(i + 1).zfill(len(str(count))))
+            out_dir, "{}{}.tif".format(prefix, names[i].replace("/", "_"))
         )
         print(f"Downloading {i + 1}/{count}: {filename}")
         download_ee_image(
@@ -12702,6 +12713,125 @@ def download_ee_image_tiles(
             unmask_value,
             **kwargs,
         )
+
+    print(f"Downloaded {count} tiles in {time.time() - start} seconds.")
+
+
+def download_ee_image_tiles_parallel(
+    image,
+    features,
+    out_dir=None,
+    prefix=None,
+    crs=None,
+    crs_transform=None,
+    scale=None,
+    resampling="near",
+    dtype=None,
+    overwrite=True,
+    num_threads=None,
+    max_tile_size=None,
+    max_tile_dim=None,
+    shape=None,
+    scale_offset=False,
+    unmask_value=None,
+    column=None,
+    job_args={"n_jobs": -1},
+    **kwargs,
+):
+    """Download an Earth Engine Image as small tiles based on ee.FeatureCollection. Images larger than the `Earth Engine size limit are split and downloaded as
+        separate tiles, then re-assembled into a single GeoTIFF. See https://github.com/dugalh/geedim/blob/main/geedim/download.py#L574
+
+    Args:
+        image (ee.Image): The image to be downloaded.
+        features (ee.FeatureCollection): The features to loop through to download image.
+        out_dir (str, optional): The output directory. Defaults to None.
+        prefix (str, optional): The prefix for the output file. Defaults to None.
+        crs (str, optional): Reproject image(s) to this EPSG or WKT CRS.  Where image bands have different CRSs, all are
+            re-projected to this CRS. Defaults to the CRS of the minimum scale band.
+        crs_transform (list, optional): tuple of float, list of float, rio.Affine, optional
+            List of 6 numbers specifying an affine transform in the specified CRS.  In row-major order:
+            [xScale, xShearing, xTranslation, yShearing, yScale, yTranslation].  All bands are re-projected to
+            this transform.
+        scale (float, optional): Resample image(s) to this pixel scale (size) (m).  Where image bands have different scales,
+            all are resampled to this scale.  Defaults to the minimum scale of image bands.
+        resampling (ResamplingMethod, optional): Resampling method, can be 'near', 'bilinear', 'bicubic', or 'average'. Defaults to None.
+        dtype (str, optional): Convert to this data type (`uint8`, `int8`, `uint16`, `int16`, `uint32`, `int32`, `float32`
+            or `float64`).  Defaults to auto select a minimum size type that can represent the range of pixel values.
+        overwrite (bool, optional): Overwrite the destination file if it exists. Defaults to True.
+        num_threads (int, optional): Number of tiles to download concurrently. Defaults to a sensible auto value.
+        max_tile_size: int, optional
+            Maximum tile size (MB).  If None, defaults to the Earth Engine download size limit (32 MB).
+        max_tile_dim: int, optional
+            Maximum tile width/height (pixels).  If None, defaults to Earth Engine download limit (10000).
+        shape: tuple of int, optional
+            (height, width) dimensions to export (pixels).
+        scale_offset: bool, optional
+            Whether to apply any EE band scales and offsets to the image.
+        unmask_value (float, optional): The value to use for pixels that are masked in the input image. If the exported image contains zero values,
+            you should set the unmask value to a  non-zero value so that the zero values are not treated as missing data. Defaults to None.
+        column (str, optional): The column name in the feature collection to use as the filename. Defaults to None.
+        job_args (dict, optional): The arguments to pass to joblib.Parallel. Defaults to {"n_jobs": -1}.
+
+    """
+    import joblib
+    import time
+
+    start = time.time()
+
+    if os.environ.get("USE_MKDOCS") is not None:
+        return
+
+    if not isinstance(features, ee.FeatureCollection):
+        raise ValueError("features must be an ee.FeatureCollection.")
+
+    if out_dir is None:
+        out_dir = os.getcwd()
+
+    if not os.path.exists(out_dir):
+        os.makedirs(out_dir)
+
+    if prefix is None:
+        prefix = ""
+
+    count = features.size().getInfo()
+    if column is not None:
+        names = features.aggregate_array(column).getInfo()
+    else:
+        names = [str(i + 1).zfill(len(str(count))) for i in range(count)]
+    collection = features.toList(count)
+
+    def download_data(index):
+        ee_initialize(opt_url="https://earthengine-highvolume.googleapis.com")
+        region = ee.Feature(collection.get(index)).geometry()
+        filename = os.path.join(
+            out_dir, "{}{}.tif".format(prefix, names[index].replace("/", "_"))
+        )
+        print(f"Downloading {index + 1}/{count}: {filename}")
+
+        download_ee_image(
+            image,
+            filename,
+            region,
+            crs,
+            crs_transform,
+            scale,
+            resampling,
+            dtype,
+            overwrite,
+            num_threads,
+            max_tile_size,
+            max_tile_dim,
+            shape,
+            scale_offset,
+            unmask_value,
+            **kwargs,
+        )
+
+    with joblib.Parallel(**job_args) as parallel:
+        parallel(joblib.delayed(download_data)(index) for index in range(count))
+
+    end = time.time()
+    print(f"Finished in {end - start} seconds.")
 
 
 def download_ee_image_collection(

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -268,6 +268,7 @@ nav:
           - notebooks/133_gradio.ipynb
           - notebooks/134_ee_to_geotiff.ipynb
           - notebooks/135_segmentation.ipynb
+          - notebooks/136_download_parallel.ipynb
     #   - miscellaneous:
     #         - notebooks/cartoee_colab.ipynb
     #         - notebooks/cartoee_colorbar.ipynb


### PR DESCRIPTION
This PR adds the `download_ee_image_tiles_parallel` function for downloading ee images in parallel with the high-volume endpoint. #1558