### PR TITLE
get_xyz_dict refactor and tests

### DIFF
--- a/geemap/geemap.py
+++ b/geemap/geemap.py
@@ -6958,7 +6958,7 @@ def get_basemap(name):
     if isinstance(name, str):
         if name in basemaps.keys():
             basemap = basemaps[name]
-            if basemap["type"] == "xyz":
+            if basemap["type"] in ["xyz", "normal", "grau"]:
                 layer = ipyleaflet.TileLayer(
                     url=basemap["url"],
                     name=basemap["name"],

--- a/tests/test_basemaps.py
+++ b/tests/test_basemaps.py
@@ -1,0 +1,75 @@
+"""Tests for `basemaps` module."""
+
+import unittest
+from unittest.mock import patch
+
+from geemap.basemaps import get_xyz_dict
+
+import xyzservices
+
+
+class FakeProvider(xyzservices.TileProvider):
+    def __init__(self, name: str, url: str):
+        super().__init__(
+            name=name,
+            url=url,
+            attribution="&copy; Fake Provider",
+            accessToken="<insert your access token here>"
+        )
+
+
+class FakeXyz(xyzservices.Bunch):
+    def __init__(self):
+        token = "https://fake-server.com/tiles/{z}/{x}/{y}?apikey={accessToken}"
+        no_token = "https://fake-server.com/tiles/{z}/{x}/{y}"
+
+        self.fake_tile_a = FakeProvider('a', no_token)
+        self.fake_tile_b = FakeProvider('b', token)
+        self.fake_tile_c_1 = FakeProvider('c_1', no_token)
+        self.fake_tile_c_France = FakeProvider('c_France', no_token)
+
+        self.providers = xyzservices.Bunch(
+            a=self.fake_tile_a,
+            b=self.fake_tile_b,
+            c=xyzservices.Bunch(
+                c_1=self.fake_tile_c_1,
+                c_2=self.fake_tile_c_France
+            )
+        )
+
+
+@patch('xyzservices.providers', FakeXyz().providers)
+class TestGetXyzDict(unittest.TestCase):
+    def test_get_xyz_dict_structure(self):
+        """Tests that get_xyz_dict returns correct object structure."""
+        xyz_dict = get_xyz_dict()
+        tile_a = xyz_dict["a"]
+        tile_a_keys = tile_a.keys()
+
+        self.assertIsInstance(xyz_dict, dict)
+        self.assertEqual("c_1", list(xyz_dict.keys())[1])
+        self.assertIsInstance(tile_a, xyzservices.lib.TileProvider)
+        self.assertIn("name", tile_a_keys)
+        self.assertIn("url", tile_a_keys)
+        self.assertIn("attribution", tile_a_keys)
+        self.assertIn("accessToken", tile_a_keys)
+        self.assertEqual("xyz", tile_a["type"])
+        self.assertEqual("a", tile_a.name)
+        self.assertEqual("https://fake-server.com/tiles/{z}/{x}/{y}",
+                         tile_a.build_url())
+
+    def test_get_xyz_dict_free_tiles(self):
+        """Tests that get_xyz_dict correctly filters for free tile layers."""
+        xyz_dict_free = get_xyz_dict(free_only=True)
+        xyz_dict_all = get_xyz_dict(free_only=False)
+
+        self.assertNotIn("b", xyz_dict_free.keys())
+        self.assertIn("b", xyz_dict_all.keys())
+
+    def test_get_xyz_dict_france_tiles(self):
+        """Tests that get_xyz_dict correctly filters for France tile layers."""
+        xyz_dict_all = get_xyz_dict(france=True)
+        xyz_dict_no_france = get_xyz_dict(france=False)
+
+        self.assertNotIn("c_France", xyz_dict_no_france.keys())
+        self.assertIn("c_France", xyz_dict_all.keys())


### PR DESCRIPTION
# Summary

This PR includes changes and tests for the basemaps.py module.

# Changes

Major changes:

1. Refactors `get_xyz_dict` to use the `xyzservices` package methods for flattening and filtering tile providers. Note that adding "type" as "xyz" for tiles is now conditioned on whether the key exists, because there are a few cases where the "type" is preset as either "normal" or "grau" for the BasemapAT tiles (for example: https://maps1.wien.gv.at/basemap/geolandbasemap/normal/google3857/9/180/275.png).
2. Adds a test file for the basemap.py module.
3. Adds tests for `get_xyz_dict` that checks for correct format, handling free bool argument, and handling france bool argument. Note that the tests are patching constructed mock provider bunch.

# Testing


## `python setup.py test`

```
(geemap_dev) braaten@braaten-cloudtop:~/Projects/geemap$ python setup.py test
running test
WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
running egg_info
writing geemap.egg-info/PKG-INFO
writing dependency_links to geemap.egg-info/dependency_links.txt
writing entry points to geemap.egg-info/entry_points.txt
writing requirements to geemap.egg-info/requires.txt
writing top-level names to geemap.egg-info/top_level.txt
reading manifest file 'geemap.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no files found matching '*' under directory 'geemap/algorithms'
warning: no previously-included files matching '__pycache__' found under directory '*'
warning: no previously-included files matching '*' found under directory 'examples'
warning: no files found matching '*.jpg' under directory 'docs'
warning: no files found matching '*.gif' under directory 'docs'
adding license file 'LICENSE'
writing manifest file 'geemap.egg-info/SOURCES.txt'
running build_ext
ok
test_get_xyz_dict_france_tiles (tests.test_basemaps.TestGetXyzDict.test_get_xyz_dict_france_tiles)
Tests that get_xyz_dict correctly filters for France tile layers. ... ok
test_get_xyz_dict_free_tiles (tests.test_basemaps.TestGetXyzDict.test_get_xyz_dict_free_tiles)
Tests that get_xyz_dict correctly filters for free tile layers. ... ok
test_get_xyz_dict_structure (tests.test_basemaps.TestGetXyzDict.test_get_xyz_dict_structure)
Tests that get_xyz_dict returns correct object structure. ... ok

----------------------------------------------------------------------
Ran 4 tests in 0.088s

OK
```

## `tox`

```
(geemap_dev) braaten@braaten-cloudtop:~/Projects/geemap$ tox
ROOT: No tox.ini or setup.cfg or pyproject.toml found, assuming empty tox.ini at /usr/local/google/home/braaten/Projects/geemap
.pkg: _optional_hooks> python /usr/local/google/home/braaten/Projects/geemap/geemap_dev/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: get_requires_for_build_sdist> python /usr/local/google/home/braaten/Projects/geemap/geemap_dev/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: get_requires_for_build_wheel> python /usr/local/google/home/braaten/Projects/geemap/geemap_dev/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: prepare_metadata_for_build_wheel> python /usr/local/google/home/braaten/Projects/geemap/geemap_dev/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: build_sdist> python /usr/local/google/home/braaten/Projects/geemap/geemap_dev/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
py: install_package> python -I -m pip install --force-reinstall --no-deps /usr/local/google/home/braaten/Projects/geemap/.tox/.tmp/package/2/geemap-0.23.0.tar.gz
.pkg: _exit> python /usr/local/google/home/braaten/Projects/geemap/geemap_dev/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
  py: OK (6.54 seconds)
  congratulations :) (6.83 seconds)
```  

## Flake8

- Ran and fixed for new file `test_basemaps.py`
- Ran and fixed for modified `basemaps.py`

## Notebook

Tested local `geemap.Map` basemap selector rendering for a sample from each provider comparing against current distribution – okay.

## Notes

This is a first PR for the basemaps.py module, I'll continue creating tests and refactoring when possible in following PRs.