### PR TITLE
Refactor xyz_to_leaflet and tests

### DIFF
--- a/geemap/basemaps.py
+++ b/geemap/basemaps.py
@@ -25,7 +25,7 @@ import xyzservices
 from .common import check_package, planet_tiles
 
 # Custom XYZ tile services.
-xyz_tiles = {
+XYZ_TILES = {
     "OpenStreetMap": {
         "url": "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
         "attribution": "OpenStreetMap",
@@ -54,7 +54,7 @@ xyz_tiles = {
 }
 
 # Custom WMS tile services.
-wms_tiles = {
+WMS_TILES = {
     "FWS NWI Wetlands": {
         "url": "https://www.fws.gov/wetlands/arcgis/services/Wetlands/MapServer/WMSServer?",
         "layers": "1",
@@ -225,6 +225,11 @@ wms_tiles = {
     },
 }
 
+custom_tiles = {
+   "xyz": XYZ_TILES,
+   "wms": WMS_TILES
+}
+
 
 def get_xyz_dict(free_only=True, france=False):
     """Returns a dictionary of xyz services.
@@ -266,21 +271,16 @@ def xyz_to_leaflet():
     """
     leaflet_dict = {}
 
-    for key in xyz_tiles:
-        xyz_tiles[key]["type"] = "xyz"
-        name = xyz_tiles[key]["name"]
-        leaflet_dict[key] = xyz_tiles[key]
+    # Add custom tiles.
+    for tile_type, tile_dict in custom_tiles.items():
+        for tile_provider, tile_info in tile_dict.items():
+            tile_info["type"] = tile_type
+            leaflet_dict[tile_info["name"]] = tile_info
 
-    for key in wms_tiles:
-        wms_tiles[key]["type"] = "wms"
-        name = wms_tiles[key]["name"]
-        leaflet_dict[key] = wms_tiles[key]
-
-    xyz_dict = get_xyz_dict()
-    for item in xyz_dict:
-        name = xyz_dict[item].name
-        xyz_dict[item]["url"] = xyz_dict[item].build_url()
-        leaflet_dict[name] = xyz_dict[item]
+    # Add xyzservices.provider tiles.
+    for tile_provider, tile_info in get_xyz_dict().items():
+        tile_info["url"] = tile_info.build_url()
+        leaflet_dict[tile_info["name"]] = tile_info
 
     return leaflet_dict
 
@@ -297,7 +297,7 @@ def xyz_to_pydeck():
 
     pydeck_dict = {}
 
-    for key, tile in xyz_tiles.items():
+    for key, tile in custom_tiles["xyz"].items():
         url = tile["url"]
         pydeck_dict[key] = url
 
@@ -331,7 +331,7 @@ def xyz_to_folium():
     """
     folium_dict = {}
 
-    for key, tile in xyz_tiles.items():
+    for key, tile in custom_tiles["xyz"].items():
         folium_dict[key] = folium.TileLayer(
             tiles=tile["url"],
             attr=tile["attribution"],
@@ -341,7 +341,7 @@ def xyz_to_folium():
             max_zoom=22,
         )
 
-    for key, tile in wms_tiles.items():
+    for key, tile in custom_tiles["wms"].items():
         folium_dict[key] = folium.WmsTileLayer(
             url=tile["url"],
             layers=tile["layers"],
@@ -378,7 +378,7 @@ def xyz_to_plotly():
     """
     plotly_dict = {}
 
-    for key, tile in xyz_tiles.items():
+    for key, tile in custom_tiles["xyz"].items():
         plotly_dict[key] = {
             "below": "traces",
             "sourcetype": "raster",

--- a/geemap/cartoee.py
+++ b/geemap/cartoee.py
@@ -15,7 +15,7 @@ import requests
 from matplotlib import cm, colors
 from matplotlib import font_manager as mfonts
 
-from .basemaps import xyz_tiles
+from .basemaps import custom_tiles
 
 try:
     import cartopy.crs as ccrs
@@ -160,7 +160,8 @@ def get_map(ee_object, proj=None, basemap=None, zoom_level=2, **kwargs):
     if basemap is not None:
         if isinstance(basemap, str):
             if basemap.upper() in ["ROADMAP", "SATELLITE", "TERRAIN", "HYBRID"]:
-                basemap = cimgt.GoogleTiles(url=xyz_tiles[basemap.upper()]["url"])
+                basemap = cimgt.GoogleTiles(
+                    url=custom_tiles["xyz"][basemap.upper()]["url"])
 
         try:
             ax.add_image(basemap, zoom_level)

--- a/tests/test_basemaps.py
+++ b/tests/test_basemaps.py
@@ -3,9 +3,58 @@
 import unittest
 from unittest.mock import patch
 
-from geemap.basemaps import get_xyz_dict
+from geemap.basemaps import custom_tiles, get_xyz_dict, xyz_to_leaflet
 
 import xyzservices
+
+
+class TestCustomTiles(unittest.TestCase):
+    def test_custom_tiles_types(self):
+        """Tests that custom_tiles is a dict and contains expected keys."""
+        self.assertIsInstance(custom_tiles, dict)
+        expected_keys = ["xyz", "wms"]
+        for key in custom_tiles.keys():
+            self.assertIn(key, expected_keys)
+
+    def test_custom_tiles_xyz(self):
+        """Tests that custom_tiles["xyz"] is a dict w/ expected keys/values."""
+        tiles = custom_tiles["xyz"]
+        self.assertIsInstance(tiles, dict)
+        for _, value in tiles.items():
+            self.assertIn("url", value)
+            self.assertIn("attribution", value)
+            self.assertIn("name", value)
+            self.assertTrue(value["url"].startswith("http"))
+
+    def test_custom_tiles_wms(self):
+        """Tests that custom_tiles["wms"] is a dict w/ expected keys/values."""
+        tiles = custom_tiles["wms"]
+        self.assertIsInstance(tiles, dict)
+        for _, value in tiles.items():
+            self.assertIsInstance(value["url"], str)
+            self.assertIsInstance(value["attribution"], str)
+            self.assertIsInstance(value["name"], str)
+            self.assertTrue(value["url"].startswith("http"))
+
+
+class TestXyzToLeaflet(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.tiles = xyz_to_leaflet()
+
+    def test_xyz_to_leaflet_is_dictionary(self):
+        """Tests that xyz_to_leaflet returns a dict."""
+        self.assertIsInstance(self.tiles, dict)
+
+    def test_xyz_to_leaflet_sources(self):
+        """Tests that xyz_to_leaflet has custom xyz, wms, and xyzservices."""
+        expected_keys = {
+            "custom_xyz": "OpenStreetMap",
+            "custom_wms": "USGS NAIP Imagery",
+            "xyzservices_xyz": "Stamen.Terrain"
+        }
+        for _, expected_name in expected_keys.items():
+            self.assertIn(expected_name, self.tiles)
 
 
 class FakeProvider(xyzservices.TileProvider):

--- a/tests/test_ee_tile_layers.py
+++ b/tests/test_ee_tile_layers.py
@@ -6,8 +6,8 @@ from unittest.mock import patch
 import box
 import ee
 
-import fake_ee
 from geemap import ee_tile_layers
+from . import fake_ee
 
 
 @patch.object(ee, "Feature", fake_ee.Feature)

--- a/tests/test_ee_tile_layers.py
+++ b/tests/test_ee_tile_layers.py
@@ -7,7 +7,7 @@ import box
 import ee
 
 from geemap import ee_tile_layers
-from . import fake_ee
+from tests import fake_ee
 
 
 @patch.object(ee, "Feature", fake_ee.Feature)


### PR DESCRIPTION
# Summary

This PR includes changes and tests for the basemaps.py module.

# Changes

1. Refactors `xyz_to_leaflet` to reduce repeated code.
2. Adds tests
    - custom tile structure
    - xyz_to_leaflet functioning
3. Had to make import of `fake_ee` relative to get `python setup.py test` to work

# Testing

## `python setup.py test`

```
test_ee_folium_tile_layer (tests.test_ee_tile_layers.TestEETileLayers.test_ee_folium_tile_layer) ... ok
test_ee_leaflet_tile_layer (tests.test_ee_tile_layers.TestEETileLayers.test_ee_leaflet_tile_layer) ... ok
test_get_tile_url_format_geometry (tests.test_ee_tile_layers.TestEETileLayers.test_get_tile_url_format_geometry) ... ok
test_get_tile_url_format_image (tests.test_ee_tile_layers.TestEETileLayers.test_get_tile_url_format_image) ... ok
test_get_tile_url_format_imagecollection (tests.test_ee_tile_layers.TestEETileLayers.test_get_tile_url_format_imagecollection) ... ok
test_get_tile_url_format_invalid_type (tests.test_ee_tile_layers.TestEETileLayers.test_get_tile_url_format_invalid_type) ... ok
test_validate_vis_params_box_palette (tests.test_ee_tile_layers.TestEETileLayers.test_validate_vis_params_box_palette) ... ok
test_validate_vis_params_box_palette_no_default (tests.test_ee_tile_layers.TestEETileLayers.test_validate_vis_params_box_palette_no_default) ... ok
test_validate_vis_params_invalid_palette_type (tests.test_ee_tile_layers.TestEETileLayers.test_validate_vis_params_invalid_palette_type) ... ok
test_validate_vis_params_list_palette (tests.test_ee_tile_layers.TestEETileLayers.test_validate_vis_params_list_palette) ... ok
test_validate_vis_params_none (tests.test_ee_tile_layers.TestEETileLayers.test_validate_vis_params_none) ... ok
test_validate_vis_params_str_palette (tests.test_ee_tile_layers.TestEETileLayers.test_validate_vis_params_str_palette) ... ok
test_custom_tiles_types (tests.test_basemaps.TestCustomTiles.test_custom_tiles_types)
Tests that custom_tiles is a dict and contains expected keys. ... ok
test_custom_tiles_wms (tests.test_basemaps.TestCustomTiles.test_custom_tiles_wms)
Tests that custom_tiles["wms"] is a dict w/ expected keys/values. ... ok
test_custom_tiles_xyz (tests.test_basemaps.TestCustomTiles.test_custom_tiles_xyz)
Tests that custom_tiles["xyz"] is a dict w/ expected keys/values. ... ok
test_get_xyz_dict_france_tiles (tests.test_basemaps.TestGetXyzDict.test_get_xyz_dict_france_tiles)
Tests that get_xyz_dict correctly filters for France tile layers. ... ok
test_get_xyz_dict_free_tiles (tests.test_basemaps.TestGetXyzDict.test_get_xyz_dict_free_tiles)
Tests that get_xyz_dict correctly filters for free tile layers. ... ok
test_get_xyz_dict_structure (tests.test_basemaps.TestGetXyzDict.test_get_xyz_dict_structure)
Tests that get_xyz_dict returns correct object structure. ... ok
test_xyz_to_leaflet_is_dictionary (tests.test_basemaps.TestXyzToLeaflet.test_xyz_to_leaflet_is_dictionary)
Tests that xyz_to_leaflet returns a dict. ... ok
test_xyz_to_leaflet_sources (tests.test_basemaps.TestXyzToLeaflet.test_xyz_to_leaflet_sources)
Tests that xyz_to_leaflet has custom xyz, wms, and xyzservices. ... ok

----------------------------------------------------------------------
Ran 21 tests in 2.438s

OK
```

## `tox`

```
ROOT: No tox.ini or setup.cfg or pyproject.toml found, assuming empty tox.ini at /usr/local/google/home/braaten/Projects/geemap
.pkg: _optional_hooks> python /usr/local/google/home/braaten/Projects/geemap/geemap_dev/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: get_requires_for_build_sdist> python /usr/local/google/home/braaten/Projects/geemap/geemap_dev/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: get_requires_for_build_wheel> python /usr/local/google/home/braaten/Projects/geemap/geemap_dev/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: prepare_metadata_for_build_wheel> python /usr/local/google/home/braaten/Projects/geemap/geemap_dev/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: build_sdist> python /usr/local/google/home/braaten/Projects/geemap/geemap_dev/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
py: install_package> python -I -m pip install --force-reinstall --no-deps /usr/local/google/home/braaten/Projects/geemap/.tox/.tmp/package/5/geemap-0.23.2.tar.gz
.pkg: _exit> python /usr/local/google/home/braaten/Projects/geemap/geemap_dev/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
  py: OK (4.11 seconds)
  congratulations :) (4.19 seconds)
```  

## Flake8

- Ran and fixed for the files/sections changed

## Notebook

Tested local `geemap.Map` basemap selector rendering for a sample from each provider comparing against current distribution – okay.
