### PR TITLE
Remove two unused variables

### DIFF
--- a/geemap/ee_tile_layers.py
+++ b/geemap/ee_tile_layers.py
@@ -74,9 +74,6 @@ def _validate_palette(palette):
 class EEFoliumTileLayer(folium.raster_layers.TileLayer):
     """A Folium raster TileLayer that shows an EE object."""
 
-    url_format = None
-    vis_params = None
-
     def __init__(
         self,
         ee_object,
@@ -112,9 +109,6 @@ class EEFoliumTileLayer(folium.raster_layers.TileLayer):
 
 class EELeafletTileLayer(ipyleaflet.TileLayer):
     """An ipyleaflet TileLayer that shows an EE object."""
-
-    url_format = None
-    vis_params = None
 
     def __init__(
         self,


### PR DESCRIPTION
This PR removes two unused variables in the ee_tile_layers module. Fix #1614

```python
url_format = None
vis_params = None
```

