### PR TITLE
Dynamic latitude in map scale calc

### DIFF
--- a/geemap/geemap.py
+++ b/geemap/geemap.py
@@ -454,8 +454,13 @@ class Map(ipyleaflet.Map):
         import math
 
         zoom_level = self.zoom
-        # Reference: https://blogs.bing.com/maps/2006/02/25/map-control-zoom-levels-gt-resolution
-        resolution = 156543.04 * math.cos(0) / math.pow(2, zoom_level)
+        center_lat = self.center[0]
+
+        # Reference:
+        # - https://blogs.bing.com/maps/2006/02/25/map-control-zoom-levels-gt-resolution
+        # - https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames#Resolution_and_Scale
+        center_lat_cos = math.cos(math.radians(center_lat))
+        resolution = 156543.04 * center_lat_cos / math.pow(2, zoom_level)
         return resolution
 
     getScale = get_scale


### PR DESCRIPTION
Map center latitude was hard-coded to 0 in calculation of approx map scale. Since latitude is non-linear in EPSG:3857, it'll be more accurate if we get the center latitude of the map and use it in the equation. At low zoom levels the scale is pretty meaningless, but at zooms of 10+ it can be useful.

I've tested the changes at +/- the same latitude around 0 and in progression from 0 to ~70 degrees and at varying zoom levels.