### PR TITLE
Remove vis_params attribute from TileLayer

### DIFF
--- a/geemap/ee_tile_layers.py
+++ b/geemap/ee_tile_layers.py
@@ -92,8 +92,7 @@ class EEFoliumTileLayer(folium.raster_layers.TileLayer):
             shown (bool, optional): A flag indicating whether the layer should be on by default. Defaults to True.
             opacity (float, optional): The layer's opacity represented as a number between 0 and 1. Defaults to 1.
         """
-        self.vis_params = _validate_vis_params(vis_params)
-        self.url_format = _get_tile_url_format(ee_object, self.vis_params)
+        self.url_format = _get_tile_url_format(ee_object, _validate_vis_params(vis_params))
         super().__init__(
             tiles=self.url_format,
             attr="Google Earth Engine",
@@ -128,8 +127,7 @@ class EELeafletTileLayer(ipyleaflet.TileLayer):
             shown (bool, optional): A flag indicating whether the layer should be on by default. Defaults to True.
             opacity (float, optional): The layer's opacity represented as a number between 0 and 1. Defaults to 1.
         """
-        self.vis_params = _validate_vis_params(vis_params)
-        self.url_format = _get_tile_url_format(ee_object, self.vis_params)
+        self.url_format = _get_tile_url_format(ee_object, _validate_vis_params(vis_params))
         super().__init__(
             url=self.url_format,
             attribution="Google Earth Engine",

--- a/geemap/geemap.py
+++ b/geemap/geemap.py
@@ -330,7 +330,7 @@ class Map(ipyleaflet.Map):
         self.ee_layer_dict[name] = {
             "ee_object": ee_object,
             "ee_layer": tile_layer,
-            "vis_params": tile_layer.vis_params,
+            "vis_params": vis_params,
         }
 
         self.add(tile_layer)

--- a/tests/test_ee_tile_layers.py
+++ b/tests/test_ee_tile_layers.py
@@ -88,7 +88,7 @@ class TestEETileLayers(unittest.TestCase):
             shown=False,
             opacity=0.5,
         )
-        self.assertEqual(layer.vis_params, {"min": 42, "palette": "#012345"})
+        # self.assertEqual(layer.vis_params, {"min": 42, "palette": "#012345"})
         self.assertEqual(layer.url_format, "url-format")
 
     def test_ee_folium_tile_layer(self):
@@ -99,5 +99,5 @@ class TestEETileLayers(unittest.TestCase):
             shown=False,
             opacity=0.5,
         )
-        self.assertEqual(layer.vis_params, {"min": 42, "palette": "#012345"})
+        # self.assertEqual(layer.vis_params, {"min": 42, "palette": "#012345"})
         self.assertEqual(layer.url_format, "url-format")


### PR DESCRIPTION
This PR removes the `vis_params` attribute from `EEFoliumTileLayer` and `EELeafletTileLayer` to avoid duplicate with `Map.ee_layer_dict`. 