### PR TITLE
Auto copy example code to clipboard

### DIFF
--- a/geemap/toolbar.py
+++ b/geemap/toolbar.py
@@ -1486,6 +1486,13 @@ def search_data_gui(m, position="topleft"):
 
             contents = "".join(code).strip()
             # create_code_cell(contents)
+
+            try:
+                import pyperclip
+                pyperclip.copy(str(contents))
+            except Exception as e:
+                pass
+
             with search_output:
                 search_output.outputs = ()
                 print(


### PR DESCRIPTION
After clicking on the import button, the converted python code will be automatically copied to the clipboard so that users don't have to manually select a long code block. 

![image](https://github.com/gee-community/geemap/assets/5016453/d73cc422-4095-48f7-81c6-493bdacab886)
