### PR TITLE
Add support for transparent legend

### DIFF
--- a/geemap/geemap.py
+++ b/geemap/geemap.py
@@ -1134,7 +1134,7 @@ class Map(ipyleaflet.Map):
                 'cmap keyword or "palette" key in vis_params must be provided.'
             )
 
-        _, ax = plt.subplots(figsize=(width, height))
+        fig, ax = plt.subplots(figsize=(width, height))
         cb = mpl.colorbar.ColorbarBase(
             ax, norm=norm, alpha=alpha, cmap=cmap, orientation=orientation, **kwargs
         )
@@ -1147,6 +1147,10 @@ class Map(ipyleaflet.Map):
         if axis_off:
             ax.set_axis_off()
         ax.tick_params(labelsize=font_size)
+
+        # set the background color to transparent
+        if transparent_bg:
+            fig.patch.set_alpha(0.0)
 
         output = widgets.Output()
         colormap_ctrl = ipyleaflet.WidgetControl(


### PR DESCRIPTION
Add `transparent_bg` parameter for supporting a transparent legend. 

![image](https://github.com/gee-community/geemap/assets/5016453/d618970c-4cee-4699-8d3f-c96deab8d1c6)
