### PR TITLE
Set Output widget max width

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,6 @@
 -   Auto copy js-py converted code to clipboard (#1621)
 -   Removed vis_params attribute from TileLayer (#1619)
 -   Dynamic latitude in map scale calc (#1618)
--
 
 ## v0.24.1 - Jul 6, 2023
 

--- a/docs/workshops/SciPy_2023.ipynb
+++ b/docs/workshops/SciPy_2023.ipynb
@@ -409,7 +409,7 @@
     "states = ee.FeatureCollection('TIGER/2018/States')\n",
     "fc = states.filter(ee.Filter.eq('NAME', 'Louisiana'))\n",
     "Map.addLayer(fc, {}, 'Louisiana')\n",
-    "Map.centerObject(fc)\n",
+    "Map.centerObject(fc, 7)\n",
     "Map"
    ]
   },
@@ -433,7 +433,7 @@
     "states = ee.FeatureCollection('TIGER/2018/States')\n",
     "fc = states.filter(ee.Filter.inList('NAME', ['California', 'Oregon', 'Washington']))\n",
     "Map.addLayer(fc, {}, 'West Coast')\n",
-    "Map.centerObject(fc)\n",
+    "Map.centerObject(fc, 5)\n",
     "Map"
    ]
   },
@@ -449,7 +449,7 @@
     "\n",
     "fc = ee.FeatureCollection('TIGER/2018/States').filterBounds(region)\n",
     "Map.addLayer(fc, {}, 'Southeastern U.S.')\n",
-    "Map.centerObject(fc)"
+    "Map.centerObject(fc, 6)"
    ]
   },
   {
@@ -514,7 +514,7 @@
    "source": [
     "### Earth Engine Data Catalog\n",
     "\n",
-    "The [Earth Engine Data Catalog](https://developers.google.com/earth-engine/datasets) hosts a variety of geospatial datasets. As of March 2023, the catalog contains over [1,000 datasets](https://github.com/samapriya/Earth-Engine-Datasets-List) with a total size of over 40 petabytes. Some notable datasets include: Landsat, Sentinel, MODIS, NAIP, etc. For a complete list of datasets in CSV or JSON formats, see the [Earth Engine Datasets List](https://github.com/giswqs/Earth-Engine-Catalog/blob/master/gee_catalog.tsv).\n",
+    "The [Earth Engine Data Catalog](https://developers.google.com/earth-engine/datasets) hosts a variety of geospatial datasets. As of March 2023, the catalog contains over [1,000 datasets](https://github.com/samapriya/Earth-Engine-Datasets-List) with a total size of over 80 petabytes. Some notable datasets include: Landsat, Sentinel, MODIS, NAIP, etc. For a complete list of datasets in CSV or JSON formats, see the [Earth Engine Datasets List](https://github.com/giswqs/Earth-Engine-Catalog/blob/master/gee_catalog.tsv).\n",
     "\n",
     "#### Searching for datasets\n",
     "\n",
@@ -790,7 +790,7 @@
     "Map = geemap.Map(center=[40, -100], zoom=4)\n",
     "Map.add_basemap('Google Hybrid')\n",
     "Map.add_basemap('NLCD 2019 CONUS Land Cover')\n",
-    "Map.add_legend(builtin_legend='NLCD')\n",
+    "Map.add_legend(builtin_legend='NLCD', max_width='100px')\n",
     "Map"
    ]
   },
@@ -942,7 +942,11 @@
    "outputs": [],
    "source": [
     "Map.add_colorbar(\n",
-    "    vis_params, label=\"Elevation (m)\", layer_name=\"SRTM DEM\", orientation=\"vertical\"\n",
+    "    vis_params, \n",
+    "    label=\"Elevation (m)\", \n",
+    "    layer_name=\"SRTM DEM\", \n",
+    "    orientation=\"vertical\",\n",
+    "    max_width=\"100px\"\n",
     ")"
    ]
   },
@@ -3126,7 +3130,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -3140,7 +3144,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/examples/workshops/SciPy_2023.ipynb
+++ b/examples/workshops/SciPy_2023.ipynb
@@ -409,7 +409,7 @@
     "states = ee.FeatureCollection('TIGER/2018/States')\n",
     "fc = states.filter(ee.Filter.eq('NAME', 'Louisiana'))\n",
     "Map.addLayer(fc, {}, 'Louisiana')\n",
-    "Map.centerObject(fc)\n",
+    "Map.centerObject(fc, 7)\n",
     "Map"
    ]
   },
@@ -433,7 +433,7 @@
     "states = ee.FeatureCollection('TIGER/2018/States')\n",
     "fc = states.filter(ee.Filter.inList('NAME', ['California', 'Oregon', 'Washington']))\n",
     "Map.addLayer(fc, {}, 'West Coast')\n",
-    "Map.centerObject(fc)\n",
+    "Map.centerObject(fc, 5)\n",
     "Map"
    ]
   },
@@ -449,7 +449,7 @@
     "\n",
     "fc = ee.FeatureCollection('TIGER/2018/States').filterBounds(region)\n",
     "Map.addLayer(fc, {}, 'Southeastern U.S.')\n",
-    "Map.centerObject(fc)"
+    "Map.centerObject(fc, 6)"
    ]
   },
   {
@@ -514,7 +514,7 @@
    "source": [
     "### Earth Engine Data Catalog\n",
     "\n",
-    "The [Earth Engine Data Catalog](https://developers.google.com/earth-engine/datasets) hosts a variety of geospatial datasets. As of March 2023, the catalog contains over [1,000 datasets](https://github.com/samapriya/Earth-Engine-Datasets-List) with a total size of over 40 petabytes. Some notable datasets include: Landsat, Sentinel, MODIS, NAIP, etc. For a complete list of datasets in CSV or JSON formats, see the [Earth Engine Datasets List](https://github.com/giswqs/Earth-Engine-Catalog/blob/master/gee_catalog.tsv).\n",
+    "The [Earth Engine Data Catalog](https://developers.google.com/earth-engine/datasets) hosts a variety of geospatial datasets. As of March 2023, the catalog contains over [1,000 datasets](https://github.com/samapriya/Earth-Engine-Datasets-List) with a total size of over 80 petabytes. Some notable datasets include: Landsat, Sentinel, MODIS, NAIP, etc. For a complete list of datasets in CSV or JSON formats, see the [Earth Engine Datasets List](https://github.com/giswqs/Earth-Engine-Catalog/blob/master/gee_catalog.tsv).\n",
     "\n",
     "#### Searching for datasets\n",
     "\n",
@@ -790,7 +790,7 @@
     "Map = geemap.Map(center=[40, -100], zoom=4)\n",
     "Map.add_basemap('Google Hybrid')\n",
     "Map.add_basemap('NLCD 2019 CONUS Land Cover')\n",
-    "Map.add_legend(builtin_legend='NLCD')\n",
+    "Map.add_legend(builtin_legend='NLCD', max_width='100px')\n",
     "Map"
    ]
   },
@@ -942,7 +942,11 @@
    "outputs": [],
    "source": [
     "Map.add_colorbar(\n",
-    "    vis_params, label=\"Elevation (m)\", layer_name=\"SRTM DEM\", orientation=\"vertical\"\n",
+    "    vis_params, \n",
+    "    label=\"Elevation (m)\", \n",
+    "    layer_name=\"SRTM DEM\", \n",
+    "    orientation=\"vertical\",\n",
+    "    max_width=\"100px\"\n",
     ")"
    ]
   },
@@ -3126,7 +3130,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -3140,7 +3144,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/geemap/geemap.py
+++ b/geemap/geemap.py
@@ -718,7 +718,9 @@ class Map(ipyleaflet.Map):
         if hasattr(self, "_plot_widget") and self._plot_widget is not None:
             plot_widget = self._plot_widget
         else:
-            plot_widget = widgets.Output(layout={"border": "1px solid black"})
+            plot_widget = widgets.Output(
+                layout={"border": "1px solid black", "max_width": "500px"}
+            )
             plot_control = ipyleaflet.WidgetControl(
                 widget=plot_widget,
                 position=position,
@@ -819,7 +821,7 @@ class Map(ipyleaflet.Map):
         if "min_width" not in kwargs:
             min_width = None
         if "max_width" not in kwargs:
-            max_width = None
+            max_width = "300px"
         else:
             max_width = kwargs["max_width"]
         if "min_height" not in kwargs:
@@ -981,6 +983,7 @@ class Map(ipyleaflet.Map):
                 widget=legend_output_widget, position=position
             )
             # legend_output.append_display_data(legend_widget)
+            legend_output.clear_output()
             with legend_output:
                 display(legend_widget)
 
@@ -1233,8 +1236,11 @@ class Map(ipyleaflet.Map):
         layer_gamma = 1
         left_value = 0
         right_value = 10000
+        max_width = "270px"
 
-        self._colorbar_widget = widgets.Output(layout=widgets.Layout(height="60px"))
+        self._colorbar_widget = widgets.Output(
+            layout=widgets.Layout(height="60px", max_width=max_width)
+        )
         self._colorbar_ctrl = ipyleaflet.WidgetControl(
             widget=self._colorbar_widget, position="bottomright"
         )
@@ -1373,7 +1379,9 @@ class Map(ipyleaflet.Map):
 
                         if self._colorbar_widget is None:
                             self._colorbar_widget = widgets.Output(
-                                layout=widgets.Layout(height="60px")
+                                layout=widgets.Layout(
+                                    height="60px", max_width=max_width
+                                )
                             )
 
                         if (not hasattr(self, "_colorbar_ctrl")) or (
@@ -1568,7 +1576,7 @@ class Map(ipyleaflet.Map):
 
                     if self._colorbar_widget is None:
                         self._colorbar_widget = widgets.Output(
-                            layout=widgets.Layout(height="60px")
+                            layout=widgets.Layout(height="60px", max_width="270px")
                         )
 
                     if (
@@ -1870,7 +1878,7 @@ class Map(ipyleaflet.Map):
                     )
 
                     self._colorbar_widget = widgets.Output(
-                        layout=widgets.Layout(height="60px")
+                        layout=widgets.Layout(height="60px", max_width=max_width)
                     )
                     self._colorbar_ctrl = ipyleaflet.WidgetControl(
                         widget=self._colorbar_widget, position="bottomright"
@@ -2166,7 +2174,9 @@ class Map(ipyleaflet.Map):
 
                         if self._colorbar_widget is None:
                             self._colorbar_widget = widgets.Output(
-                                layout=widgets.Layout(height="60px")
+                                layout=widgets.Layout(
+                                    height="60px", max_width=max_width
+                                )
                             )
 
                         if self._colorbar_ctrl is None:
@@ -2213,7 +2223,7 @@ class Map(ipyleaflet.Map):
 
                     if self._colorbar_widget is None:
                         self._colorbar_widget = widgets.Output(
-                            layout=widgets.Layout(height="60px")
+                            layout=widgets.Layout(height="60px", max_width=max_width)
                         )
 
                     if self._colorbar_ctrl is None:
@@ -2285,7 +2295,7 @@ class Map(ipyleaflet.Map):
                         self._colorbar_widget.close()
 
                     self._colorbar_widget = widgets.Output(
-                        layout=widgets.Layout(height="60px")
+                        layout=widgets.Layout(height="60px", max_width=max_width)
                     )
                     self._colorbar_ctrl = ipyleaflet.WidgetControl(
                         widget=self._colorbar_widget, position="bottomright"

--- a/geemap/toolbar.py
+++ b/geemap/toolbar.py
@@ -358,7 +358,11 @@ def inspector_gui(m=None):
 
         if not hasattr(m, "inspector_output"):
             inspector_output = widgets.Output(
-                layout=widgets.Layout(width=widget_width, padding="0px 5px 5px 5px")
+                layout=widgets.Layout(
+                    width=widget_width,
+                    padding="0px 5px 5px 5px",
+                    max_width=widget_width,
+                )
             )
             setattr(m, "inspector_output", inspector_output)
 
@@ -721,6 +725,7 @@ def ee_inspector_gui(
     position="topright",
     opened=True,
     show_close_button=True,
+    max_width="300px",
 ):
     """Earth Engine Inspector GUI.
 
@@ -732,6 +737,7 @@ def ee_inspector_gui(
         position (str, optional): The position of the control. Defaults to "topright".
         opened (bool, optional): Whether the control is opened. Defaults to True.
         show_close_button (bool, optional): Whether to show the close button. Defaults to True.
+        max_width
 
     """
     from ipytree import Tree
@@ -758,7 +764,7 @@ def ee_inspector_gui(
 
     layout = {
         "border": "1px solid black",
-        "max_width": "600px",
+        "max_width": max_width,
         "max_height": "500px",
         "overflow": "auto",
     }
@@ -1048,11 +1054,11 @@ def layer_manager_gui(
                         if layer_name in m.ee_layer_names:
                             layer_dict = m.ee_layer_dict[layer_name]
 
-                            if hasattr(m, '_vis_widget') and m._vis_widget is not None:
+                            if hasattr(m, "_vis_widget") and m._vis_widget is not None:
                                 m._vis_widget = None
                             m._vis_widget = m.create_vis_widget(layer_dict)
                             if (
-                                hasattr(m, '_vis_control')
+                                hasattr(m, "_vis_control")
                                 and m._vis_control in m.controls
                             ):
                                 m.remove_control(m._vis_control)
@@ -1063,7 +1069,7 @@ def layer_manager_gui(
                             m.add((vis_control))
                             m._vis_control = vis_control
                         else:
-                            if hasattr(m, '_vis_widget') and m._vis_widget is not None:
+                            if hasattr(m, "_vis_widget") and m._vis_widget is not None:
                                 m._vis_widget = None
                             if m._vis_control is not None:
                                 if m._vis_control in m.controls:
@@ -1489,6 +1495,7 @@ def search_data_gui(m, position="topleft"):
 
             try:
                 import pyperclip
+
                 pyperclip.copy(str(contents))
             except Exception as e:
                 pass


### PR DESCRIPTION
Recent ipywidgets version breaks Output widget logic. We need to set the max_width paramter. Otherwise, the widget might take the full width, which does not look good.