### PR TITLE
Improve Sentinel-2 timelapse function

### DIFF
--- a/geemap/timelapse.py
+++ b/geemap/timelapse.py
@@ -1533,7 +1533,7 @@ def sentinel2_timeseries(
     doy_start = ee.Number.parse(ee.Date(start).format("D"))
     doy_end = ee.Number.parse(ee.Date(end).format("D"))
     collection = (
-        ee.ImageCollection("COPERNICUS/S2_SR_HARMONIZED")
+        ee.ImageCollection("COPERNICUS/S2_HARMONIZED")
         .filterDate(start, end)
         .filter(ee.Filter.calendarRange(doy_start, doy_end, "day_of_year"))
         .filter(ee.Filter.lt("CLOUDY_PIXEL_PERCENTAGE", cloud_pct))
@@ -1542,6 +1542,10 @@ def sentinel2_timeseries(
 
     if mask_cloud:
         collection = collection.map(maskS2clouds)
+    else:
+        collection = collection.map(
+            lambda img: img.divide(10000).set(img.toDictionary(img.propertyNames()))
+        )
 
     if bands is not None:
         allowed_bands = {


### PR DESCRIPTION
This PR changes the `sentinel2_timelapse` function to use `S2_HARMONIZED`, which has a long timespan than `S2_SR_HARMONIZED`

```python
import ee
import geemap
geemap.ee_initialize()
roi = ee.Geometry.BBox(104.295181, 3.570619,104.395181, 3.670619)
geemap.sentinel2_timelapse(
    roi, 
    'S2.gif',  
    2016, 
    2017, 
    start_date='02-01', 
    end_date='03-30', 
    frequency='day', 
    apply_fmask=False,
    frames_per_second=0.5,
    )
```
![S2](https://github.com/gee-community/geemap/assets/5016453/ddd7834a-72e6-4628-86ca-6a40a47d1548)

