### PR TITLE
Add codes to 114_dynamic_world.ipynb

### DIFF
--- a/examples/notebooks/114_dynamic_world.ipynb
+++ b/examples/notebooks/114_dynamic_world.ipynb
@@ -1,119 +1,163 @@
 {
-    "cells": [
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "<a href=\"https://githubtocolab.com/gee-community/geemap/blob/master/examples/notebooks/114_dynamic_world.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open in Colab\"/></a>\n",
-                "\n",
-                "**Creating near real-time global 10-m land cover maps with geemap and Dynamic World**\n",
-                "\n",
-                "- App: https://www.dynamicworld.app\n",
-                "- App2: https://earthoutreach.users.earthengine.app/view/dynamicworld\n",
-                "- Paper: https://doi.org/10.1038/s41597-022-01307-4\n",
-                "- Model: https://github.com/google/dynamicworld\n",
-                "- Training data: https://doi.pangaea.de/10.1594/PANGAEA.933475\n",
-                "- Data: https://developers.google.com/earth-engine/datasets/catalog/GOOGLE_DYNAMICWORLD_V1\n",
-                "- JavaScript tutorial: https://developers.google.com/earth-engine/tutorials/community/introduction-to-dynamic-world-pt-1"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "import ee\n",
-                "import geemap"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "Map = geemap.Map()\n",
-                "Map.add_basemap('HYBRID')\n",
-                "Map"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "# Set the region of interest by simply drawing a polygon on the map\n",
-                "region = Map.user_roi\n",
-                "if region is None:\n",
-                "    region = ee.Geometry.BBox(-89.7088, 42.9006, -89.0647, 43.2167)\n",
-                "\n",
-                "Map.centerObject(region)"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "# Set the date range\n",
-                "start_date = '2021-01-01'\n",
-                "end_date = '2022-01-01'"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "# Create a Sentinel-2 image composite\n",
-                "image = geemap.dynamic_world_s2(region, start_date, end_date)\n",
-                "vis_params = {'bands': ['B4', 'B3', 'B2'], 'min': 0, 'max': 3000}\n",
-                "Map.addLayer(image, vis_params, 'Sentinel-2 image')"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "# Create Dynamic World land cover composite\n",
-                "landcover = geemap.dynamic_world(region, start_date, end_date, return_type='hillshade')\n",
-                "Map.addLayer(landcover, {}, 'Land Cover')"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {
-                "tags": []
-            },
-            "outputs": [],
-            "source": [
-                "# Add legend to the map\n",
-                "Map.add_legend(title=\"Dynamic World Land Cover\", builtin_legend='Dynamic_World')\n",
-                "Map"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "![](https://i.imgur.com/GEzsSii.png)"
-            ]
-        }
-    ],
-    "metadata": {
-        "kernelspec": {
-            "display_name": "Python 3",
-            "language": "python",
-            "name": "python3"
-        }
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "oz4mAK4uuu16"
+      },
+      "source": [
+        "<a href=\"https://githubtocolab.com/gee-community/geemap/blob/master/examples/notebooks/114_dynamic_world.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open in Colab\"/></a>\n",
+        "\n",
+        "**Creating near real-time global 10-m land cover maps with geemap and Dynamic World**\n",
+        "\n",
+        "- App: https://www.dynamicworld.app\n",
+        "- App2: https://earthoutreach.users.earthengine.app/view/dynamicworld\n",
+        "- Paper: https://doi.org/10.1038/s41597-022-01307-4\n",
+        "- Model: https://github.com/google/dynamicworld\n",
+        "- Training data: https://doi.pangaea.de/10.1594/PANGAEA.933475\n",
+        "- Data: https://developers.google.com/earth-engine/datasets/catalog/GOOGLE_DYNAMICWORLD_V1\n",
+        "- JavaScript tutorial: https://developers.google.com/earth-engine/tutorials/community/introduction-to-dynamic-world-pt-1"
+      ],
+      "id": "oz4mAK4uuu16"
     },
-    "nbformat": 4,
-    "nbformat_minor": 5
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "7Cf5PSGNuu19"
+      },
+      "outputs": [],
+      "source": [
+        "import ee\n",
+        "import geemap"
+      ],
+      "id": "7Cf5PSGNuu19"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "z-bJd8Reuu1-"
+      },
+      "outputs": [],
+      "source": [
+        "Map = geemap.Map()\n",
+        "Map.add_basemap('HYBRID')\n",
+        "Map"
+      ],
+      "id": "z-bJd8Reuu1-"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "oQkJa0Xzuu1-"
+      },
+      "outputs": [],
+      "source": [
+        "# Set the region of interest by simply drawing a polygon on the map\n",
+        "region = Map.user_roi\n",
+        "if region is None:\n",
+        "    region = ee.Geometry.BBox(-89.7088, 42.9006, -89.0647, 43.2167)\n",
+        "\n",
+        "Map.centerObject(region)"
+      ],
+      "id": "oQkJa0Xzuu1-"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "gkQcggxRuu1_"
+      },
+      "outputs": [],
+      "source": [
+        "# Set the date range\n",
+        "start_date = '2021-01-01'\n",
+        "end_date = '2022-01-01'"
+      ],
+      "id": "gkQcggxRuu1_"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "7yBvgunJuu1_"
+      },
+      "outputs": [],
+      "source": [
+        "# Create a Sentinel-2 image composite\n",
+        "image = geemap.dynamic_world_s2(region, start_date, end_date)\n",
+        "vis_params = {'bands': ['B4', 'B3', 'B2'], 'min': 0, 'max': 3000}\n",
+        "Map.addLayer(image, vis_params, 'Sentinel-2 image')"
+      ],
+      "id": "7yBvgunJuu1_"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "RRnATqO8uu1_"
+      },
+      "outputs": [],
+      "source": [
+        "# Create Dynamic World land cover composite\n",
+        "landcover = geemap.dynamic_world(region, start_date, end_date, return_type='hillshade')\n",
+        "Map.addLayer(landcover, {}, 'Land Cover')"
+      ],
+      "id": "RRnATqO8uu1_"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "tags": [],
+        "id": "ft0fqSCKuu1_"
+      },
+      "outputs": [],
+      "source": [
+        "# Add legend to the map\n",
+        "Map.add_legend(title=\"Dynamic World Land Cover\", builtin_legend='Dynamic_World')\n",
+        "Map"
+      ],
+      "id": "ft0fqSCKuu1_"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "6rvNY7fWuu2A"
+      },
+      "source": [
+        "![](https://i.imgur.com/GEzsSii.png)"
+      ],
+      "id": "6rvNY7fWuu2A"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Save Dynamic World class data in GeoTIFF format\n",
+        "output_path = 'landcover.tif'\n",
+        "landcover = geemap.dynamic_world(region, start_date, end_date, return_type='class')\n",
+        "geemap.ee_export_image(landcover, filename=output_path, scale=10, region=region, file_per_band=False)"
+      ],
+      "metadata": {
+        "id": "OxkTIXHluwRO"
+      },
+      "id": "OxkTIXHluwRO",
+      "execution_count": null,
+      "outputs": []
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "colab": {
+      "provenance": []
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
 }


### PR DESCRIPTION
As you know, Earth Engine Dynamic World products are divided into hillshade, probability, visualize, and class according to return_types. In my opinion, it would be nice to add information on how to save class data as GeoTIFF.

```
# Save Dynamic World class data as GeoTIFF format
output_path = 'landcover.tif'
landcover = geemap.dynamic_world(region, start_date, end_date, return_type='class')
geemap.ee_export_image(landcover, filename=output_path, scale=10, region=region, file_per_band=False)
```