### PR TITLE
Fix PIL import error on Windows

### DIFF
--- a/geemap/timelapse.py
+++ b/geemap/timelapse.py
@@ -15,8 +15,12 @@ import shutil
 import ee
 
 from .common import *
-from PIL import Image
 from typing import Union, List
+
+try:
+    from PIL import Image
+except:
+    pass
 
 
 def add_overlay(


### PR DESCRIPTION
It appears that PIL.Image is not working properly on Windows for Python 3.11. This PR skips importing PIL if it fails.
https://github.com/giswqs/geebook/issues/3