### PR TITLE
Add installation CI

### DIFF
--- a/.github/workflows/installation.yml
+++ b/.github/workflows/installation.yml
@@ -1,0 +1,26 @@
+on:
+    push:
+        branches:
+            - master
+    pull_request:
+        branches:
+            - master
+
+name: Linux installation
+jobs:
+    test-ubuntu:
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                python-version: ["3.10"]
+        steps:
+            - uses: actions/checkout@v3
+            - name: Set up Python
+              uses: actions/setup-python@v4
+              with:
+                  python-version: ${{ matrix.python-version }}
+            - name: Install dependencies
+              run: |
+                  pip install .
+                  python -c "import geemap"

--- a/.github/workflows/installation.yml
+++ b/.github/workflows/installation.yml
@@ -20,7 +20,7 @@ jobs:
               uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.python-version }}
-            - name: Install dependencies
-              run: |
-                  pip install .
-                  python -c "import geemap; print('geemap import successful')"
+            - name: Install package
+              run: pip install .
+            - name: Test import
+              run: python -c "import geemap; print('geemap import successful')"

--- a/.github/workflows/installation.yml
+++ b/.github/workflows/installation.yml
@@ -23,4 +23,4 @@ jobs:
             - name: Install dependencies
               run: |
                   pip install .
-                  python -c "import geemap"
+                  python -c "import geemap; print('geemap import successful')"


### PR DESCRIPTION
This PR add a CI for testing geemap installation and `import geemap`. This is pure instllation without any optional dependencies. This CI can avoid installation issues for new users.