### PR TITLE
Refactor toolbar into an ipywidgets subclass

### DIFF
--- a/geemap/geemap.py
+++ b/geemap/geemap.py
@@ -2788,9 +2788,10 @@ class Map(ipyleaflet.Map):
             position (str, optional): The position of the toolbar. Defaults to "topright".
         """
 
-        from .toolbar import main_toolbar
-
-        main_toolbar(self, position, **kwargs)
+        from .toolbar import Toolbar, main_tools, extra_tools
+        self._toolbar = Toolbar(self, main_tools, extra_tools)
+        toolbar_control = ipyleaflet.WidgetControl(widget=self._toolbar, position=position)
+        self.add(toolbar_control)
 
     def add_plot_gui(self, position="topright", **kwargs):
         """Adds the plot widget to the map.
@@ -4145,10 +4146,7 @@ class Map(ipyleaflet.Map):
     def toolbar_reset(self):
         """Reset the toolbar so that no tool is selected."""
         if hasattr(self, "_toolbar"):
-            toolbar_grid = self._toolbar
-            if toolbar_grid is not None:
-                for tool in toolbar_grid.children:
-                    tool.value = False
+            self._toolbar.reset()
 
     def add_raster(
         self,

--- a/geemap/map_widgets.py
+++ b/geemap/map_widgets.py
@@ -1,5 +1,6 @@
 """Various ipywidgets that can be added to a map."""
 
+import ipyleaflet
 import ipywidgets
 
 from . import common

--- a/geemap/map_widgets.py
+++ b/geemap/map_widgets.py
@@ -1,6 +1,5 @@
 """Various ipywidgets that can be added to a map."""
 
-import ipyleaflet
 import ipywidgets
 
 from . import common

--- a/geemap/toolbar.py
+++ b/geemap/toolbar.py
@@ -28,7 +28,7 @@ class Toolbar(widgets.VBox):
 
     @dataclass
     class Item:
-        """A represenation of an item in the toolbar.
+        """A representation of an item in the toolbar.
 
         Attributes:
             icon: The icon to use for the item, from https://fontawesome.com/icons.

--- a/geemap/toolbar.py
+++ b/geemap/toolbar.py
@@ -4706,8 +4706,7 @@ main_tools = [
     Toolbar.Item(
         icon="info",
         tooltip="Inspector",
-        callback=lambda m, selected: m.add_inspector() if selected
-        else None,
+        callback=lambda m, selected: m.add_inspector() if selected else None,
     ),
     Toolbar.Item(
         icon="bar-chart",

--- a/tests/test_toolbar.py
+++ b/tests/test_toolbar.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+
+"""Tests for `map_widgets` module."""
+
+
+import unittest
+from unittest.mock import patch, MagicMock, ANY
+import geemap
+from geemap.toolbar import Toolbar, main_tools, extra_tools
+
+
+class TestToolbar(unittest.TestCase):
+    """Tests for the Toolbar class in the `toolbar` module."""
+
+    def setUp(self) -> None:
+        self.callback_calls = 0
+        self.last_called_with_selected = None
+        self.item = Toolbar.Item(
+            icon="info", tooltip="dummy item", callback=self.dummy_callback
+        )
+        self.no_reset_item = Toolbar.Item(
+            icon="question",
+            tooltip="no reset item",
+            callback=self.dummy_callback,
+            reset=False,
+        )
+        return super().setUp()
+
+    def tearDown(self) -> None:
+        patch.stopall()
+        return super().tearDown()
+
+    def dummy_callback(self, m, selected):
+        del m
+        self.last_called_with_selected = selected
+        self.callback_calls += 1
+
+    def test_no_tools_throws(self):
+        map = geemap.Map()
+        self.assertRaises(ValueError, Toolbar, map, [], [])
+
+    def test_only_main_tools_exist_if_no_extra_tools(self):
+        map = geemap.Map()
+        toolbar = Toolbar(map, [self.item], [])
+        self.assertIsNone(toolbar.toggle_widget)
+        self.assertEqual(len(toolbar.all_widgets), 1)
+        self.assertEqual(toolbar.all_widgets[0].icon, "info")
+        self.assertEqual(toolbar.all_widgets[0].tooltip, "dummy item")
+        self.assertFalse(toolbar.all_widgets[0].value)
+
+    def test_all_tools_and_toggle_exist_if_extra_tools(self):
+        map = geemap.Map()
+        toolbar = Toolbar(map, [self.item], [self.no_reset_item])
+        self.assertIsNotNone(toolbar.toggle_widget)
+        self.assertEqual(len(toolbar.all_widgets), 3)
+        self.assertEqual(toolbar.all_widgets[2].icon, "question")
+        self.assertEqual(toolbar.all_widgets[2].tooltip, "no reset item")
+        self.assertFalse(toolbar.all_widgets[2].value)
+
+    def test_toggle_expands_and_collapses(self):
+        map = geemap.Map()
+        toolbar = Toolbar(map, [self.item], [self.no_reset_item])
+        self.assertEqual(len(toolbar.grid.children), 2)
+        self.assertIsNotNone(toolbar.toggle_widget)
+        toggle = toolbar.all_widgets[1]
+        self.assertEqual(toggle.icon, "plus")
+        self.assertEqual(toggle.tooltip, "Expand toolbar")
+
+        # Expand
+        toggle.value = True
+        self.assertEqual(len(toolbar.grid.children), 3)
+        self.assertEqual(toggle.icon, "minus")
+        self.assertEqual(toggle.tooltip, "Collapse toolbar")
+        # After expanding, button is unselected.
+        self.assertFalse(toggle.value)
+
+        # Collapse
+        toggle.value = True
+        self.assertEqual(len(toolbar.grid.children), 2)
+        self.assertEqual(toggle.icon, "plus")
+        self.assertEqual(toggle.tooltip, "Expand toolbar")
+        # After collapsing, button is unselected.
+        self.assertFalse(toggle.value)
+
+    def test_triggers_callbacks(self):
+        map = geemap.Map()
+        toolbar = Toolbar(map, [self.item, self.no_reset_item])
+        self.assertIsNone(self.last_called_with_selected)
+
+        # Select first tool, which resets.
+        toolbar.all_widgets[0].value = True
+        self.assertFalse(self.last_called_with_selected)  # was reset by callback
+        self.assertEqual(self.callback_calls, 2)
+        self.assertFalse(toolbar.all_widgets[0].value)
+
+        # Select second tool, which does not reset.
+        toolbar.all_widgets[1].value = True
+        self.assertTrue(self.last_called_with_selected)
+        self.assertEqual(self.callback_calls, 3)
+        self.assertTrue(toolbar.all_widgets[1].value)

--- a/tests/test_toolbar.py
+++ b/tests/test_toolbar.py
@@ -36,11 +36,11 @@ class TestToolbar(unittest.TestCase):
         self.callback_calls += 1
 
     def test_no_tools_throws(self):
-        map = geemap.Map()
+        map = geemap.Map(ee_initialize=False)
         self.assertRaises(ValueError, Toolbar, map, [], [])
 
     def test_only_main_tools_exist_if_no_extra_tools(self):
-        map = geemap.Map()
+        map = geemap.Map(ee_initialize=False)
         toolbar = Toolbar(map, [self.item], [])
         self.assertIsNone(toolbar.toggle_widget)
         self.assertEqual(len(toolbar.all_widgets), 1)
@@ -49,7 +49,7 @@ class TestToolbar(unittest.TestCase):
         self.assertFalse(toolbar.all_widgets[0].value)
 
     def test_all_tools_and_toggle_exist_if_extra_tools(self):
-        map = geemap.Map()
+        map = geemap.Map(ee_initialize=False)
         toolbar = Toolbar(map, [self.item], [self.no_reset_item])
         self.assertIsNotNone(toolbar.toggle_widget)
         self.assertEqual(len(toolbar.all_widgets), 3)
@@ -58,7 +58,7 @@ class TestToolbar(unittest.TestCase):
         self.assertFalse(toolbar.all_widgets[2].value)
 
     def test_toggle_expands_and_collapses(self):
-        map = geemap.Map()
+        map = geemap.Map(ee_initialize=False)
         toolbar = Toolbar(map, [self.item], [self.no_reset_item])
         self.assertEqual(len(toolbar.grid.children), 2)
         self.assertIsNotNone(toolbar.toggle_widget)
@@ -83,7 +83,7 @@ class TestToolbar(unittest.TestCase):
         self.assertFalse(toggle.value)
 
     def test_triggers_callbacks(self):
-        map = geemap.Map()
+        map = geemap.Map(ee_initialize=False)
         toolbar = Toolbar(map, [self.item, self.no_reset_item])
         self.assertIsNone(self.last_called_with_selected)
 


### PR DESCRIPTION
Created a new dataclass, `Toolbar.Item`, that defines an entry in the Toolbar.

Once `layer_manager_gui()` is widgetized, we can move the new Toolbar widget into `map_widgets.py`.  The code remaining in `toolbar.py` will become simpler as the view and control separate.

Future work can also include implementing `plotly_toolbar` the same way. 

Note that I uncommented the implementations for the help and gee tool items.  If they are not needed, we can remove them (I think it is better to remove than to keep commented out code)