### PR TITLE
Defines an AbstractDrawControl and implementation for the current draw control features. 

### DIFF
--- a/geemap/geemap.py
+++ b/geemap/geemap.py
@@ -75,9 +75,7 @@ class MapDrawControl(ipyleaflet.DrawControl, map_widgets.AbstractDrawControl):
                 self._roi_end = True
                 self._roi_start = False
             except Exception as e:
-                self.geometries = []
-                self.properties = []
-                self.last_geometry = None
+                self.reset(clear_draw_control=False)
                 self._roi_start = False
                 self._roi_end = False
                 print("There was an error creating Earth Engine Feature.")

--- a/geemap/geemap.py
+++ b/geemap/geemap.py
@@ -35,13 +35,14 @@ from . import examples
 
 basemaps = Box(xyz_to_leaflet(), frozen_box=True)
 
+
 class MapDrawControl(ipyleaflet.DrawControl, map_widgets.AbstractDrawControl):
     """"Implements the AbstractDrawControl for the map."""
     _roi_start = False
     _roi_end = False
 
     def __init__(self, host_map, **kwargs):
-         super(MapDrawControl,self).__init__(host_map=host_map, **kwargs)
+        super(MapDrawControl, self).__init__(host_map=host_map, **kwargs)
 
     @property
     def user_roi(self):
@@ -50,7 +51,7 @@ class MapDrawControl(ipyleaflet.DrawControl, map_widgets.AbstractDrawControl):
     @property
     def user_rois(self):
         return self.collection
-    
+
     # NOTE: Overridden for backwards compatibility, where edited geometries are
     # added to the layer instead of modified in place. Remove when
     # https://github.com/jupyter-widgets/ipyleaflet/issues/1119 is fixed to
@@ -114,15 +115,19 @@ class Map(ipyleaflet.Map):
     @property
     def draw_features(self):
         return self.draw_control.features if self.draw_control else []
+
     @property
     def draw_last_feature(self):
         return self.draw_control.last_feature if self.draw_control else None
+
     @property
     def draw_layer(self):
         return self.draw_control.layer if self.draw_control else None
+
     @property
     def user_roi(self):
         return self.draw_control.user_roi if self.draw_control else None
+
     @property
     def user_rois(self):
         return self.draw_control.user_rois if self.draw_control else None

--- a/geemap/geemap.py
+++ b/geemap/geemap.py
@@ -37,19 +37,35 @@ basemaps = Box(xyz_to_leaflet(), frozen_box=True)
 
 
 class MapDrawControl(ipyleaflet.DrawControl, map_widgets.AbstractDrawControl):
-    """"Implements the AbstractDrawControl for the map."""
+    """ "Implements the AbstractDrawControl for the map."""
+
     _roi_start = False
     _roi_end = False
 
     def __init__(self, host_map, **kwargs):
+        """Initialize the map draw control.
+
+        Args:
+            host_map (geemap.Map): The geemap.Map object that the control will be added to.
+        """
         super(MapDrawControl, self).__init__(host_map=host_map, **kwargs)
 
     @property
     def user_roi(self):
+        """Returns the last drawn geometry.
+
+        Returns:
+            ee.Geometry: Last drawn geometry.
+        """
         return self.last_geometry
 
     @property
     def user_rois(self):
+        """Returns all drawn geometries as an ee.FeatureCollection.
+
+        Returns:
+            ee.FeatureCollection: All drawn geometries.
+        """
         return self.collection
 
     # NOTE: Overridden for backwards compatibility, where edited geometries are
@@ -81,6 +97,7 @@ class MapDrawControl(ipyleaflet.DrawControl, map_widgets.AbstractDrawControl):
                 self._roi_end = False
                 print("There was an error creating Earth Engine Feature.")
                 raise Exception(e)
+
         self.on_draw(handle_draw)
         # NOTE: Uncomment the following code once
         # https://github.com/jupyter-widgets/ipyleaflet/issues/1119 is fixed
@@ -2546,7 +2563,9 @@ class Map(ipyleaflet.Map):
                 self.inspector_control.close()
                 self.inspector_control = None
 
-        inspector = map_widgets.Inspector(self, names, visible, decimals, opened, show_close_button)
+        inspector = map_widgets.Inspector(
+            self, names, visible, decimals, opened, show_close_button
+        )
         inspector.on_close = _on_close
         self.inspector_control = ipyleaflet.WidgetControl(
             widget=inspector, position=position
@@ -2620,8 +2639,11 @@ class Map(ipyleaflet.Map):
         """
 
         from .toolbar import Toolbar, main_tools, extra_tools
+
         self._toolbar = Toolbar(self, main_tools, extra_tools)
-        toolbar_control = ipyleaflet.WidgetControl(widget=self._toolbar, position=position)
+        toolbar_control = ipyleaflet.WidgetControl(
+            widget=self._toolbar, position=position
+        )
         self.add(toolbar_control)
 
     def add_plot_gui(self, position="topright", **kwargs):
@@ -4096,6 +4118,7 @@ class Map(ipyleaflet.Map):
             raise Exception("The source must be a URL.")
 
     def remove_draw_control(self):
+        """Removes the draw control from the map"""
         controls = []
         old_draw_control = None
         for control in self.controls:
@@ -4121,9 +4144,9 @@ class Map(ipyleaflet.Map):
                 self.remove_drawn_features()
             elif self.draw_control.count:
                 self.draw_control.remove_geometry(self.draw_control.geometries[-1])
-                if hasattr(self, '_chart_values'):
+                if hasattr(self, "_chart_values"):
                     self._chart_values = self._chart_values[:-1]
-                if hasattr(self, '_chart_points'):
+                if hasattr(self, "_chart_points"):
                     self._chart_points = self._chart_points[:-1]
                 # self._chart_labels = None
 

--- a/geemap/geemap.py
+++ b/geemap/geemap.py
@@ -35,6 +35,72 @@ from . import examples
 
 basemaps = Box(xyz_to_leaflet(), frozen_box=True)
 
+class MapDrawControl(ipyleaflet.DrawControl, map_widgets.AbstractDrawControl):
+    """"Implements the AbstractDrawControl for the map."""
+    _roi_start = False
+    _roi_end = False
+
+    def __init__(self, host_map, **kwargs):
+         super(MapDrawControl,self).__init__(host_map=host_map, **kwargs)
+
+    @property
+    def user_roi(self):
+        return self.last_geometry
+
+    @property
+    def user_rois(self):
+        return self.collection
+    
+    # NOTE: Overridden for backwards compatibility, where edited geometries are
+    # added to the layer instead of modified in place. Remove when
+    # https://github.com/jupyter-widgets/ipyleaflet/issues/1119 is fixed to
+    # allow geometry edits to be reflected on the tile layer.
+    def _handle_geometry_edited(self, geo_json):
+        return self._handle_geometry_created(geo_json)
+
+    def _get_synced_geojson_from_draw_control(self):
+        return [data.copy() for data in self.data]
+
+    def _bind_to_draw_control(self):
+        # Handles draw events
+        def handle_draw(_, action, geo_json):
+            try:
+                self._roi_start = True
+                if action == "created":
+                    self._handle_geometry_created(geo_json)
+                elif action == "edited":
+                    self._handle_geometry_edited(geo_json)
+                elif action == "deleted":
+                    self._handle_geometry_deleted(geo_json)
+                self._roi_end = True
+                self._roi_start = False
+            except Exception as e:
+                self.geometries = []
+                self.properties = []
+                self.last_geometry = None
+                self._roi_start = False
+                self._roi_end = False
+                print("There was an error creating Earth Engine Feature.")
+                raise Exception(e)
+        self.on_draw(handle_draw)
+        # NOTE: Uncomment the following code once
+        # https://github.com/jupyter-widgets/ipyleaflet/issues/1119 is fixed
+        # to allow edited geometries to be reflected instead of added.
+        # def handle_data_update(_):
+        #     self._sync_geometries()
+        # self.observe(handle_data_update, 'data')
+
+    def _remove_geometry_at_index_on_draw_control(self, index):
+        # NOTE: Uncomment the following code once
+        # https://github.com/jupyter-widgets/ipyleaflet/issues/1119 is fixed to
+        # remove drawn geometries with `remove_last_drawn()`.
+        # del self.data[index]
+        # self.send_state(key='data')
+        pass
+
+    def _clear_draw_control(self):
+        return self.clear()
+
 
 class Map(ipyleaflet.Map):
     """The Map class inherits the ipyleaflet Map class. The arguments you can pass to the Map initialization
@@ -45,6 +111,23 @@ class Map(ipyleaflet.Map):
     Returns:
         object: ipyleaflet map object.
     """
+
+    # Map attributes for drawing features
+    @property
+    def draw_features(self):
+        return self.draw_control.features if self.draw_control else []
+    @property
+    def draw_last_feature(self):
+        return self.draw_control.last_feature if self.draw_control else None
+    @property
+    def draw_layer(self):
+        return self.draw_control.layer if self.draw_control else None
+    @property
+    def user_roi(self):
+        return self.draw_control.user_roi if self.draw_control else None
+    @property
+    def user_rois(self):
+        return self.draw_control.user_rois if self.draw_control else None
 
     def __init__(self, **kwargs):
         """Initialize a map object. The following additional parameters can be passed in addition to the ipyleaflet.Map parameters:
@@ -169,13 +252,6 @@ class Map(ipyleaflet.Map):
             for control in bottomright_controls:
                 if kwargs.get(control, True):
                     self.add_controls(control, position="bottomright")
-
-        # Map attributes for drawing features
-        self.draw_features = []
-        self.draw_last_feature = None
-        self.draw_layer = None
-        self.user_roi = None
-        self.user_rois = None
 
         # Map attributes for layers
         self.geojson_layers = []
@@ -2500,8 +2576,8 @@ class Map(ipyleaflet.Map):
         Args:
             position (str, optional): The position of the draw control. Defaults to "topleft".
         """
-
-        draw_control = ipyleaflet.DrawControl(
+        draw_control = MapDrawControl(
+            host_map=self,
             marker={"shapeOptions": {"color": "#3388ff"}},
             rectangle={"shapeOptions": {"color": "#3388ff"}},
             # circle={"shapeOptions": {"color": "#3388ff"}},
@@ -2510,50 +2586,6 @@ class Map(ipyleaflet.Map):
             remove=True,
             position=position,
         )
-
-        # Handles draw events
-        def handle_draw(target, action, geo_json):
-            try:
-                self._roi_start = True
-                geom = geojson_to_ee(geo_json, False)
-                self.user_roi = geom
-                feature = ee.Feature(geom)
-                self.draw_last_feature = feature
-                if not hasattr(self, "_draw_count"):
-                    self._draw_count = 0
-                if action == "deleted" and len(self.draw_features) > 0:
-                    self.draw_features.remove(feature)
-                    self._draw_count -= 1
-                else:
-                    self.draw_features.append(feature)
-                    self._draw_count += 1
-                collection = ee.FeatureCollection(self.draw_features)
-                self.user_rois = collection
-                ee_draw_layer = EELeafletTileLayer(
-                    collection, {"color": "blue"}, "Drawn Features", False, 0.5
-                )
-                draw_layer_index = self.find_layer_index("Drawn Features")
-
-                if draw_layer_index == -1:
-                    self.add(ee_draw_layer)
-                    self.draw_layer = ee_draw_layer
-                else:
-                    self.substitute_layer(self.draw_layer, ee_draw_layer)
-                    self.draw_layer = ee_draw_layer
-                self._roi_end = True
-                self._roi_start = False
-            except Exception as e:
-                self._draw_count = 0
-                self.draw_features = []
-                self.draw_last_feature = None
-                self.draw_layer = None
-                self.user_roi = None
-                self._roi_start = False
-                self._roi_end = False
-                print("There was an error creating Earth Engine Feature.")
-                raise Exception(e)
-
-        draw_control.on_draw(handle_draw)
         self.add(draw_control)
         self.draw_control = draw_control
 
@@ -4060,46 +4092,36 @@ class Map(ipyleaflet.Map):
         else:
             raise Exception("The source must be a URL.")
 
+    def remove_draw_control(self):
+        controls = []
+        old_draw_control = None
+        for control in self.controls:
+            if isinstance(control, MapDrawControl):
+                old_draw_control = control
+
+            else:
+                controls.append(control)
+
+        self.controls = tuple(controls)
+        if old_draw_control:
+            old_draw_control.close()
+
     def remove_drawn_features(self):
         """Removes user-drawn geometries from the map"""
-        if self.draw_layer is not None:
-            self.remove_layer(self.draw_layer)
-            self._draw_count = 0
-            self.draw_features = []
-            self.draw_last_feature = None
-            self.draw_layer = None
-            self.user_roi = None
-            self.user_rois = None
-            self._chart_values = []
-            self._chart_points = []
-            self._chart_labels = None
         if self.draw_control is not None:
-            self.draw_control.clear()
+            self.draw_control.reset()
 
     def remove_last_drawn(self):
-        """Removes user-drawn geometries from the map"""
-        if self.draw_layer is not None:
-            collection = ee.FeatureCollection(self.draw_features[:-1])
-            ee_draw_layer = EELeafletTileLayer(
-                collection, {"color": "blue"}, "Drawn Features", True, 0.5
-            )
-            if self._draw_count == 1:
+        """Removes last user-drawn geometry from the map"""
+        if self.draw_control is not None:
+            if self.draw_control.count == 1:
                 self.remove_drawn_features()
-            else:
-                self.substitute_layer(self.draw_layer, ee_draw_layer)
-                self.draw_layer = ee_draw_layer
-                self._draw_count -= 1
-                self.draw_features = self.draw_features[:-1]
-                self.draw_last_feature = self.draw_features[-1]
-                self.draw_layer = ee_draw_layer
-                self.user_roi = ee.Feature(
-                    collection.toList(collection.size()).get(
-                        collection.size().subtract(1)
-                    )
-                ).geometry()
-                self.user_rois = collection
-                self._chart_values = self._chart_values[:-1]
-                self._chart_points = self._chart_points[:-1]
+            elif self.draw_control.count:
+                self.draw_control.remove_geometry(self.draw_control.geometries[-1])
+                if hasattr(self, '_chart_values'):
+                    self._chart_values = self._chart_values[:-1]
+                if hasattr(self, '_chart_points'):
+                    self._chart_points = self._chart_points[:-1]
                 # self._chart_labels = None
 
     def extract_values_to_points(self, filename):

--- a/geemap/map_widgets.py
+++ b/geemap/map_widgets.py
@@ -470,6 +470,7 @@ class AbstractDrawControl(object):
         """Resets the draw controls."""
         if self.layer is not None:
             self.host_map.remove_layer(self.layer)
+        self.data = []  # Remove all drawn features from the map.
         self.geometries = []
         self.properties = []
         self.last_geometry = None

--- a/geemap/map_widgets.py
+++ b/geemap/map_widgets.py
@@ -382,7 +382,7 @@ class Inspector(ipywidgets.VBox):
         return self._root_node("Objects", nodes)
 
 
-class DrawActions(enum.StrEnum):
+class DrawActions(enum.Enum):
     CREATED='created'
     EDITED='edited'
     DELETED='deleted'
@@ -423,7 +423,7 @@ class AbstractDrawControl(object):
 
     @property
     def collection(self):
-        return ee.FeatureCollection(self.features) if self.count else None
+        return ee.FeatureCollection(self.features if self.count else [])
 
     @property
     def last_feature(self):
@@ -434,7 +434,7 @@ class AbstractDrawControl(object):
     def count(self):
         return len(self.geometries)
 
-    def reset(self, clear_draw_control=True):
+    def reset(self, clear_draw_control=False):
         """Resets the draw controls."""
         if self.layer is not None:
             self.host_map.remove_layer(self.layer)
@@ -446,7 +446,12 @@ class AbstractDrawControl(object):
             self._clear_draw_control()
 
     def remove_geometry(self, geometry):
-        index = self.geometries.index(geometry)
+        if not geometry:
+            return
+        try:
+            index = self.geometries.index(geometry)
+        except ValueError:
+            return
         if index >= 0:
             del self.geometries[index]
             del self.properties[index]
@@ -459,14 +464,24 @@ class AbstractDrawControl(object):
                 self._redraw_layer()
 
     def get_geometry_properties(self, geometry):
-        index = self.geometries.index(geometry)
+        if not geometry:
+            return None
+        try:
+            index = self.geometries.index(geometry)
+        except ValueError:
+            return None
         if index >= 0:
             return self.properties[index]
         else:
             return None
 
     def set_geometry_properties(self, geometry, property):
-        index = self.geometries.index(geometry)
+        if not geometry:
+            return
+        try:
+            index = self.geometries.index(geometry)
+        except ValueError:
+            return
         if index >= 0:
             self.properties[index] = property
 

--- a/geemap/map_widgets.py
+++ b/geemap/map_widgets.py
@@ -1,10 +1,13 @@
 """Various ipywidgets that can be added to a map."""
 
+import enum
+
 import ee
 import ipytree
 import ipywidgets
 
 from . import common
+from .ee_tile_layers import EELeafletTileLayer
 
 
 class Colorbar(ipywidgets.Output):
@@ -377,3 +380,177 @@ class Inspector(ipywidgets.VBox):
                     nodes.append(tree_node)
 
         return self._root_node("Objects", nodes)
+
+
+class DrawActions(enum.StrEnum):
+    CREATED='created'
+    EDITED='edited'
+    DELETED='deleted'
+    REMOVED_LAST='removed-last'
+
+
+class AbstractDrawControl(object):
+    host_map = None
+    layer = None
+    geometries = []
+    properties = []
+    last_geometry = None
+    last_draw_action = None
+    _geometry_create_dispatcher = ipywidgets.CallbackDispatcher()
+    _geometry_edit_dispatcher = ipywidgets.CallbackDispatcher()
+    _geometry_delete_dispatcher = ipywidgets.CallbackDispatcher()
+
+    def __init__(self, host_map):
+        self.host_map = host_map
+        self.layer = None
+        self.geometries = []
+        self.properties = []
+        self.last_geometry = None
+        self.last_draw_action = None
+        self._geometry_create_dispatcher = ipywidgets.CallbackDispatcher()
+        self._geometry_edit_dispatcher = ipywidgets.CallbackDispatcher()
+        self._geometry_delete_dispatcher = ipywidgets.CallbackDispatcher()
+        self._bind_to_draw_control()
+
+    @property
+    def features(self):
+        if self.count:
+            return [
+                ee.Feature(geometry, self.properties[i]) for i, geometry in enumerate(self.geometries)
+            ]
+        else:
+            return []
+
+    @property
+    def collection(self):
+        return ee.FeatureCollection(self.features) if self.count else None
+
+    @property
+    def last_feature(self):
+        property = self.get_geometry_properties(self.last_geometry)
+        return ee.Feature(self.last_geometry, property) if self.last_geometry else None
+
+    @property
+    def count(self):
+        return len(self.geometries)
+
+    def reset(self):
+        """Resets the draw controls."""
+        if self.layer is not None:
+            self.host_map.remove_layer(self.layer)
+        self.geometries = []
+        self.properties = []
+        self.last_geometry = None
+        self.layer = None
+        self._clear_draw_control()
+
+    def remove_geometry(self, geometry):
+        index = self.geometries.index(geometry)
+        if index >= 0:
+            del self.geometries[index]
+            del self.properties[index]
+            self._remove_geometry_at_index_on_draw_control(index)
+            if index == self.count and geometry == self.last_geometry:
+                # Treat this like an "undo" of the last drawn geometry.
+                self.last_geometry = self.geometries[-1]
+                self.last_draw_action = DrawActions.REMOVED_LAST
+            if self.layer is not None:
+                self._redraw_layer()
+
+    def get_geometry_properties(self, geometry):
+        index = self.geometries.index(geometry)
+        if index >= 0:
+            return self.properties[index]
+        else:
+            return None
+
+    def set_geometry_properties(self, geometry, property):
+        index = self.geometries.index(geometry)
+        if index >= 0:
+            self.properties[index] = property
+
+    def on_geometry_create(self, callback, remove=False):
+        self._geometry_create_dispatcher.register_callback(callback, remove=remove)
+
+    def on_geometry_edit(self, callback, remove=False):
+        self._geometry_edit_dispatcher.register_callback(callback, remove=remove)
+
+    def on_geometry_delete(self, callback, remove=False):
+        self._geometry_delete_dispatcher.register_callback(callback, remove=remove)
+
+    def _bind_to_draw_control(self):
+        """Set up draw control event handling like create, edit, and delete."""
+        raise NotImplementedError()
+    
+    def _remove_geometry_at_index_on_draw_control(self):
+        """Remove the geometry at the given index on the draw control."""
+        raise NotImplementedError()
+
+    def _clear_draw_control(self):
+        """Clears the geometries from the draw control."""
+        raise NotImplementedError()
+
+    def _get_synced_geojson_from_draw_control(self):
+        """Returns an up-to-date of GeoJSON from the draw control."""
+        raise NotImplementedError()
+
+    def _sync_geometries(self):
+        """Sync the local geometries with those from the draw control."""
+        if not self.count:
+            return
+        # The current geometries from the draw_control.
+        test_geojsons = self._get_synced_geojson_from_draw_control()
+        i = 0
+        while i < self.count and i < len(test_geojsons):
+            local_geometry = None
+            test_geometry = None
+            while i < self.count and i < len(test_geojsons):
+                local_geometry = self.geometries[i]
+                test_geometry = common.geojson_to_ee(test_geojsons[i], False)
+                if test_geometry == local_geometry:
+                    i += 1
+                else:
+                    break
+            if i < self.count and test_geometry is not None:
+                    self.geometries[i] = test_geometry
+        if self.layer is not None:
+            self._redraw_layer()
+
+    def _redraw_layer(self):
+        layer = EELeafletTileLayer(
+            self.collection, {"color": "blue"}, "Drawn Features", False, 0.5
+        )
+        if self.host_map:
+            layer_index = self.host_map.find_layer_index("Drawn Features")
+            if layer_index == -1:
+                self.host_map.add_layer(layer)
+            else:
+                self.host_map.substitute(self.host_map.layers[layer_index], layer)
+        self.layer = layer
+    
+    def _handle_geometry_created(self, geo_json):
+        geometry = common.geojson_to_ee(geo_json, False)
+        self.last_geometry = geometry
+        self.last_draw_action = DrawActions.CREATED
+        self.geometries.append(geometry)
+        self.properties.append(None)
+        self._redraw_layer()
+        self._geometry_create_dispatcher(self, geometry=geometry)
+
+    def _handle_geometry_edited(self, geo_json):
+        geometry = common.geojson_to_ee(geo_json, False)
+        self.last_geometry = geometry
+        self.last_draw_action = DrawActions.EDITED
+        self._sync_geometries()
+        self._redraw_layer()
+        self._geometry_edit_dispatcher(self, geometry=geometry)
+
+    def _handle_geometry_deleted(self, geo_json):
+        geometry = common.geojson_to_ee(geo_json, False)
+        self.last_geometry = geometry
+        self.last_draw_action = DrawActions.DELETED
+        i = self.geometries.index(geometry)
+        del self.geometries[i]
+        del self.properties[i]
+        self._redraw_layer()
+        self._geometry_delete_dispatcher(self, geometry=geometry)

--- a/geemap/map_widgets.py
+++ b/geemap/map_widgets.py
@@ -434,7 +434,7 @@ class AbstractDrawControl(object):
     def count(self):
         return len(self.geometries)
 
-    def reset(self):
+    def reset(self, clear_draw_control=True):
         """Resets the draw controls."""
         if self.layer is not None:
             self.host_map.remove_layer(self.layer)
@@ -442,7 +442,8 @@ class AbstractDrawControl(object):
         self.properties = []
         self.last_geometry = None
         self.layer = None
-        self._clear_draw_control()
+        if clear_draw_control:
+            self._clear_draw_control()
 
     def remove_geometry(self, geometry):
         index = self.geometries.index(geometry)

--- a/geemap/map_widgets.py
+++ b/geemap/map_widgets.py
@@ -383,10 +383,10 @@ class Inspector(ipywidgets.VBox):
 
 
 class DrawActions(enum.Enum):
-    CREATED='created'
-    EDITED='edited'
-    DELETED='deleted'
-    REMOVED_LAST='removed-last'
+    CREATED = 'created'
+    EDITED = 'edited'
+    DELETED = 'deleted'
+    REMOVED_LAST = 'removed-last'
 
 
 class AbstractDrawControl(object):
@@ -415,9 +415,14 @@ class AbstractDrawControl(object):
     @property
     def features(self):
         if self.count:
-            return [
-                ee.Feature(geometry, self.properties[i]) for i, geometry in enumerate(self.geometries)
-            ]
+            features = []
+            for i, geometry in enumerate(self.geometries):
+                if i < len(self.properties):
+                    property = self.properties[i]
+                else:
+                    property = None
+                features.append(ee.Feature(geometry, property))
+            return features
         else:
             return []
 
@@ -497,7 +502,7 @@ class AbstractDrawControl(object):
     def _bind_to_draw_control(self):
         """Set up draw control event handling like create, edit, and delete."""
         raise NotImplementedError()
-    
+
     def _remove_geometry_at_index_on_draw_control(self):
         """Remove the geometry at the given index on the draw control."""
         raise NotImplementedError()
@@ -528,7 +533,7 @@ class AbstractDrawControl(object):
                 else:
                     break
             if i < self.count and test_geometry is not None:
-                    self.geometries[i] = test_geometry
+                self.geometries[i] = test_geometry
         if self.layer is not None:
             self._redraw_layer()
 
@@ -543,7 +548,7 @@ class AbstractDrawControl(object):
             else:
                 self.host_map.substitute(self.host_map.layers[layer_index], layer)
         self.layer = layer
-    
+
     def _handle_geometry_created(self, geo_json):
         geometry = common.geojson_to_ee(geo_json, False)
         self.last_geometry = geometry

--- a/geemap/map_widgets.py
+++ b/geemap/map_widgets.py
@@ -142,6 +142,8 @@ class Colorbar(ipywidgets.Output):
 
 
 class Inspector(ipywidgets.VBox):
+    """Inspector widget for Earth Engine data."""
+
     def __init__(
         self,
         host_map,
@@ -151,6 +153,17 @@ class Inspector(ipywidgets.VBox):
         opened=True,
         show_close_button=True,
     ):
+        """Creates an Inspector widget for Earth Engine data.
+
+        Args:
+            host_map (geemap.Map): The map to add the inspector widget to.
+            names (list, optional): The list of layer names to be inspected. Defaults to None.
+            visible (bool, optional): Whether to inspect visible layers only. Defaults to True.
+            decimals (int, optional): The number of decimal places to round the values. Defaults to 2.
+            opened (bool, optional): Whether the inspector is opened. Defaults to True.
+            show_close_button (bool, optional): Whether to show the close button. Defaults to True.
+        """
+
         self._host_map = host_map
         if not host_map:
             raise ValueError("Must pass a valid map when creating an inspector.")
@@ -383,13 +396,21 @@ class Inspector(ipywidgets.VBox):
 
 
 class DrawActions(enum.Enum):
-    CREATED = 'created'
-    EDITED = 'edited'
-    DELETED = 'deleted'
-    REMOVED_LAST = 'removed-last'
+    """Action types for the draw control.
+
+    Args:
+        enum (str): Action type.
+    """
+
+    CREATED = "created"
+    EDITED = "edited"
+    DELETED = "deleted"
+    REMOVED_LAST = "removed-last"
 
 
 class AbstractDrawControl(object):
+    """Abstract class for the draw control."""
+
     host_map = None
     layer = None
     geometries = []
@@ -401,6 +422,12 @@ class AbstractDrawControl(object):
     _geometry_delete_dispatcher = ipywidgets.CallbackDispatcher()
 
     def __init__(self, host_map):
+        """Initialize the draw control.
+
+        Args:
+            host_map (geemap.Map): The geemap.Map instance to be linked with the draw control.
+        """
+
         self.host_map = host_map
         self.layer = None
         self.geometries = []
@@ -451,6 +478,7 @@ class AbstractDrawControl(object):
             self._clear_draw_control()
 
     def remove_geometry(self, geometry):
+        """Removes a geometry from the draw control."""
         if not geometry:
             return
         try:
@@ -469,6 +497,7 @@ class AbstractDrawControl(object):
                 self._redraw_layer()
 
     def get_geometry_properties(self, geometry):
+        """Gets the properties of a geometry."""
         if not geometry:
             return None
         try:
@@ -481,6 +510,7 @@ class AbstractDrawControl(object):
             return None
 
     def set_geometry_properties(self, geometry, property):
+        """Sets the properties of a geometry."""
         if not geometry:
             return
         try:

--- a/geemap/toolbar.py
+++ b/geemap/toolbar.py
@@ -2159,7 +2159,7 @@ def collect_samples(m):
             if len(color.value) != 7:
                 color.value = "#3388ff"
             draw_control = MapDrawControl(
-                host_map = m,
+                host_map=m,
                 marker={"shapeOptions": {"color": color.value}, "repeatMode": False},
                 rectangle={"shapeOptions": {"color": color.value}, "repeatMode": False},
                 polygon={"shapeOptions": {"color": color.value}, "repeatMode": False},

--- a/geemap/toolbar.py
+++ b/geemap/toolbar.py
@@ -2191,6 +2191,7 @@ def collect_samples(m):
             def set_properties(_, geometry):
                 if len(train_props) > 0:
                     draw_control.set_geometry_properties(geometry, train_props)
+
             draw_control.on_geometry_create(set_properties)
 
         elif change["new"] == "Clear":
@@ -4689,7 +4690,7 @@ extra_tools = [
     Toolbar.Item(
         icon="eraser",
         tooltip="Remove all drawn features",
-        callback=lambda m, selected: max.remove_drawn_features() if selected else None,
+        callback=lambda m, selected: m.remove_drawn_features() if selected else None,
     ),
     Toolbar.Item(
         icon="folder-open",


### PR DESCRIPTION
AbstractDrawControl
===

- The goal for this PR is to extract as much of the draw control functionality into its own abstract class  so that we can build any draw control for any map implementation but will always provide the same, backwards compatible API for users of geemap. To do this, we define a new abstract class, `AbstractDrawControl`, which acts an interface between any map's draw control functionality (like [ipyleaflet's `DrawControl`](https://ipyleaflet.readthedocs.io/en/latest/controls/draw_control.html)) to the user's geemap code.
- The class requires the following methods to be implemented for a given draw control, like ipyleaflet's `DrawControl`, and the rest of the API takes care of keeping the geometries, feature list, and feature collections in sync for the user to use in their script:
```
    def _bind_to_draw_control(self):
        """Set up draw control event handling like create, edit, and delete."""
        raise NotImplementedError()
    
    def _remove_geometry_at_index_on_draw_control(self):
        """Remove the geometry at the given index on the draw control."""
        raise NotImplementedError()

    def _clear_draw_control(self):
        """Clears the geometries from the draw control."""
        raise NotImplementedError()

    def _get_synced_geojson_from_draw_control(self):
        """Returns an up-to-date of GeoJSON from the draw control."""
        raise NotImplementedError()
```
- I've implemented a new class, `MapDrawControl` which extends the ipyleaflet's `DrawControl` so that user's can continue using the draw control API exactly as they have been (I hope).
- Unfortunately, there's a [bug in the base ipyleaflet `DrawControl`](https://github.com/jupyter-widgets/ipyleaflet/issues/1119) that disallows us to keep the edited geometries in sync with the stored geometries in geemap. Notably, this bug is not present in Colab notebooks, but is present in Jupyter Labs. I have [proposed a fix for it in ipyleaflet](https://github.com/jupyter-widgets/ipyleaflet/pull/1133). After this fix is in, we can consider keeping the geometries in sync with the drawn geometries using ipyleaflet's `DrawControl` data field. Until then, I kept the existing behavior where edited geometries are added instead of modified in place. 
- I also implemented some fixes to the toolbar's "Collect training samples" drawing feature. Now it will properly reset the draw control back to the default one after the user hits "Close."

Unfortunately, I'm not expert at using geemap so I will need your help to figure out if this change won't break existing scripts!
