### PR TITLE
Add NLCD 2021 basemap

### DIFF
--- a/geemap/basemaps.py
+++ b/geemap/basemaps.py
@@ -78,6 +78,14 @@ WMS_TILES = {
         "format": "image/png",
         "transparent": True,
     },
+    "NLCD 2021 CONUS Land Cover": {
+        "url": "https://www.mrlc.gov/geoserver/mrlc_display/NLCD_2021_Land_Cover_L48/wms?",
+        "layers": "NLCD_2021_Land_Cover_L48",
+        "name": "NLCD 2021 CONUS Land Cover",
+        "attribution": "MRLC",
+        "format": "image/png",
+        "transparent": True,
+    },
     "NLCD 2019 CONUS Land Cover": {
         "url": "https://www.mrlc.gov/geoserver/mrlc_display/NLCD_2019_Land_Cover_L48/wms?",
         "layers": "NLCD_2019_Land_Cover_L48",


### PR DESCRIPTION
NLCD 2021 is now available. This PR adds the NLCD 2021 WMS basemap. 
https://www.mrlc.gov/data/nlcd-2021-land-cover-conus