### PR TITLE
Remove Google basemaps

### DIFF
--- a/geemap/basemaps.py
+++ b/geemap/basemaps.py
@@ -2,14 +2,6 @@
 
 Each basemap is defined as an item in the `basemaps` dictionary.
 
-For example, to access Google basemaps, users first need to get a Google Maps API key from https://bit.ly/3sw0THG.
-    Then, set the environment variable using geemap.set_api_key(<API-KEY>). Then Google basemaps can be accessed using:
-
-    * `basemaps['ROADMAP']`
-    * `basemaps['SATELLITE']`
-    * `basemaps['TERRAIN']`
-    * `basemaps['HYBRID']`
-
 More WMS basemaps can be found at the following websites:
 
   1. USGS National Map: https://viewer.nationalmap.gov/services/
@@ -33,67 +25,33 @@ import ipyleaflet
 import xyzservices
 from .common import check_package, planet_tiles
 
-GOOGLE_MAPS_API_KEY = os.environ.get("GOOGLE_MAPS_API_KEY", "")
-
 XYZ_TILES = {
     "OpenStreetMap": {
         "url": "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
         "attribution": "OpenStreetMap",
         "name": "OpenStreetMap",
     },
+    "ROADMAP": {
+        "url": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}",
+        "attribution": "Esri",
+        "name": "Esri.WorldStreetMap",
+    },
+    "SATELLITE": {
+        "url": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+        "attribution": "Esri",
+        "name": "Esri.WorldImagery",
+    },
+    "TERRAIN": {
+        "url": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}",
+        "attribution": "Esri",
+        "name": "Esri.WorldTopoMap",
+    },
+    "HYBRID": {
+        "url": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+        "attribution": "Esri",
+        "name": "Esri.WorldImagery",
+    },
 }
-
-# Add Google basemaps if API key is detected in the environment variables.
-if GOOGLE_MAPS_API_KEY != "":
-    XYZ_TILES.update(
-        {
-            "ROADMAP": {
-                "url": f"https://mt1.google.com/vt/lyrs=m&x={{x}}&y={{y}}&z={{z}}&key={GOOGLE_MAPS_API_KEY}",
-                "attribution": "Google",
-                "name": "Google Maps",
-            },
-            "SATELLITE": {
-                "url": f"https://mt1.google.com/vt/lyrs=s&x={{x}}&y={{y}}&z={{z}}&key={GOOGLE_MAPS_API_KEY}",
-                "attribution": "Google",
-                "name": "Google Satellite",
-            },
-            "TERRAIN": {
-                "url": f"https://mt1.google.com/vt/lyrs=p&x={{x}}&y={{y}}&z={{z}}&key={GOOGLE_MAPS_API_KEY}",
-                "attribution": "Google",
-                "name": "Google Terrain",
-            },
-            "HYBRID": {
-                "url": f"https://mt1.google.com/vt/lyrs=y&x={{x}}&y={{y}}&z={{z}}&key={GOOGLE_MAPS_API_KEY}",
-                "attribution": "Google",
-                "name": "Google Hybrid",
-            },
-        }
-    )
-else:  # If Google Maps API key is not detected, defaulting to Esri basemaps.
-    XYZ_TILES.update(
-        {
-            "ROADMAP": {
-                "url": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}",
-                "attribution": "Esri",
-                "name": "Esri.WorldStreetMap",
-            },
-            "SATELLITE": {
-                "url": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
-                "attribution": "Esri",
-                "name": "Esri.WorldImagery",
-            },
-            "TERRAIN": {
-                "url": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}",
-                "attribution": "Esri",
-                "name": "Esri.WorldTopoMap",
-            },
-            "HYBRID": {
-                "url": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
-                "attribution": "Esri",
-                "name": "Esri.WorldImagery",
-            },
-        }
-    )
 
 
 # Custom WMS tile services.

--- a/geemap/common.py
+++ b/geemap/common.py
@@ -125,16 +125,6 @@ def ee_initialize(
         ee.data.setUserAgent(user_agent)
 
 
-def set_api_key(key: str, name: str = "GOOGLE_MAPS_API_KEY"):
-    """Sets the Google Maps API key. You can generate one from https://bit.ly/3sw0THG.
-
-    Args:
-        key (str): The Google Maps API key.
-        name (str, optional): The name of the environment variable. Defaults to "GOOGLE_MAPS_API_KEY".
-    """
-    os.environ[name] = key
-
-
 def ee_export_image(
     ee_object,
     filename,
@@ -14883,32 +14873,32 @@ def tms_to_geotiff(
         SESSION = requests.Session()
 
     xyz_tiles = {
-        "OPENSTREETMAP": {
-            "url": "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
-            "attribution": "OpenStreetMap",
-            "name": "OpenStreetMap",
-        },
-        "ROADMAP": {
-            "url": "https://mt1.google.com/vt/lyrs=m&x={x}&y={y}&z={z}",
-            "attribution": "Google",
-            "name": "Google Maps",
-        },
-        "SATELLITE": {
-            "url": "https://mt1.google.com/vt/lyrs=s&x={x}&y={y}&z={z}",
-            "attribution": "Google",
-            "name": "Google Satellite",
-        },
-        "TERRAIN": {
-            "url": "https://mt1.google.com/vt/lyrs=p&x={x}&y={y}&z={z}",
-            "attribution": "Google",
-            "name": "Google Terrain",
-        },
-        "HYBRID": {
-            "url": "https://mt1.google.com/vt/lyrs=y&x={x}&y={y}&z={z}",
-            "attribution": "Google",
-            "name": "Google Satellite",
-        },
-    }
+    "OpenStreetMap": {
+        "url": "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+        "attribution": "OpenStreetMap",
+        "name": "OpenStreetMap",
+    },
+    "ROADMAP": {
+        "url": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}",
+        "attribution": "Esri",
+        "name": "Esri.WorldStreetMap",
+    },
+    "SATELLITE": {
+        "url": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+        "attribution": "Esri",
+        "name": "Esri.WorldImagery",
+    },
+    "TERRAIN": {
+        "url": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}",
+        "attribution": "Esri",
+        "name": "Esri.WorldTopoMap",
+    },
+    "HYBRID": {
+        "url": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+        "attribution": "Esri",
+        "name": "Esri.WorldImagery",
+    },
+}
 
     if isinstance(source, str) and source.upper() in xyz_tiles:
         source = xyz_tiles[source.upper()]["url"]
@@ -15442,106 +15432,3 @@ def widget_template(
 
     else:
         return toolbar_widget
-
-
-def get_google_map(
-    map_type="HYBRID", show=True, api_key=None, backend="ipyleaflet", **kwargs
-):
-    """Gets Google basemap tile layer.
-
-    Args:
-        map_type (str, optional): Can be one of "ROADMAP", "SATELLITE", "HYBRID" or "TERRAIN". Defaults to 'HYBRID'.
-        show (bool, optional): Whether to add the layer to the map. Defaults to True.
-        api_key (str, optional): The Google Maps API key. Defaults to None.
-        **kwargs: Additional arguments to pass to ipyleaflet.TileLayer().
-    """
-
-    allow_types = ["ROADMAP", "SATELLITE", "HYBRID", "TERRAIN"]
-    if map_type not in allow_types:
-        print("map_type must be one of the following: {}".format(allow_types))
-        return
-
-    if api_key is None:
-        api_key = os.environ.get("GOOGLE_MAPS_API_KEY", "")
-
-    if api_key == "":
-        MAP_TILES = {
-            "ROADMAP": {
-                "url": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}",
-                "attribution": "Esri",
-                "name": "Esri.WorldStreetMap",
-            },
-            "SATELLITE": {
-                "url": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
-                "attribution": "Esri",
-                "name": "Esri.WorldImagery",
-            },
-            "TERRAIN": {
-                "url": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}",
-                "attribution": "Esri",
-                "name": "Esri.WorldTopoMap",
-            },
-            "HYBRID": {
-                "url": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
-                "attribution": "Esri",
-                "name": "Esri.WorldImagery",
-            },
-        }
-
-        print(
-            "Google Maps API key is required to use Google Maps. You can generate one from https://bit.ly/3sw0THG and use geemap.set_api_key(), defaulting to Esri basemaps."
-        )
-
-    else:
-        MAP_TILES = {
-            "ROADMAP": {
-                "url": f"https://mt1.google.com/vt/lyrs=m&x={{x}}&y={{y}}&z={{z}}&key={api_key}",
-                "attribution": "Google",
-                "name": "Google Maps",
-            },
-            "SATELLITE": {
-                "url": f"https://mt1.google.com/vt/lyrs=s&x={{x}}&y={{y}}&z={{z}}&key={api_key}",
-                "attribution": "Google",
-                "name": "Google Satellite",
-            },
-            "TERRAIN": {
-                "url": f"https://mt1.google.com/vt/lyrs=p&x={{x}}&y={{y}}&z={{z}}&key={api_key}",
-                "attribution": "Google",
-                "name": "Google Terrain",
-            },
-            "HYBRID": {
-                "url": f"https://mt1.google.com/vt/lyrs=y&x={{x}}&y={{y}}&z={{z}}&key={api_key}",
-                "attribution": "Google",
-                "name": "Google Hybrid",
-            },
-        }
-
-    if "max_zoom" not in kwargs:
-        kwargs["max_zoom"] = 24
-
-    if backend == "ipyleaflet":
-        import ipyleaflet
-
-        layer = ipyleaflet.TileLayer(
-            url=MAP_TILES[map_type]["url"],
-            name=MAP_TILES[map_type]["name"],
-            attribution=MAP_TILES[map_type]["attribution"],
-            visible=show,
-            **kwargs,
-        )
-    elif backend == "folium":
-        import folium
-
-        layer = folium.TileLayer(
-            tiles=MAP_TILES[map_type]["url"],
-            name=MAP_TILES[map_type]["name"],
-            attr=MAP_TILES[map_type]["attribution"],
-            overlay=True,
-            control=True,
-            show=show,
-            **kwargs,
-        )
-    else:
-        raise ValueError("backend must be either 'ipyleaflet' or 'folium'")
-
-    return layer

--- a/geemap/common.py
+++ b/geemap/common.py
@@ -125,6 +125,16 @@ def ee_initialize(
         ee.data.setUserAgent(user_agent)
 
 
+def set_api_key(key: str, name: str = "GOOGLE_MAPS_API_KEY"):
+    """Sets the Google Maps API key. You can generate one from https://bit.ly/3sw0THG.
+
+    Args:
+        key (str): The Google Maps API key.
+        name (str, optional): The name of the environment variable. Defaults to "GOOGLE_MAPS_API_KEY".
+    """
+    os.environ[name] = key
+
+
 def ee_export_image(
     ee_object,
     filename,
@@ -9489,19 +9499,6 @@ def get_api_key(token_name, m=None):
     return api_key
 
 
-def set_api_key(token_name, api_key, m=None):
-    """Sets an API key as an environment variable.
-
-    Args:
-        token_name (str): The token name.
-        api_key (str): The API key.
-        m (ipyleaflet.Map | folium.Map, optional): A Map instance.. Defaults to None.
-    """
-    os.environ[token_name] = api_key
-    if m is not None:
-        m.api_keys[token_name] = api_key
-
-
 def planet_monthly_tropical(api_key=None, token_name="PLANET_API_KEY"):
     """Generates Planet monthly imagery URLs based on an API key. See https://assets.planet.com/docs/NICFI_UserGuidesFAQ.pdf
 
@@ -15445,3 +15442,106 @@ def widget_template(
 
     else:
         return toolbar_widget
+
+
+def get_google_map(
+    map_type="HYBRID", show=True, api_key=None, backend="ipyleaflet", **kwargs
+):
+    """Gets Google basemap tile layer.
+
+    Args:
+        map_type (str, optional): Can be one of "ROADMAP", "SATELLITE", "HYBRID" or "TERRAIN". Defaults to 'HYBRID'.
+        show (bool, optional): Whether to add the layer to the map. Defaults to True.
+        api_key (str, optional): The Google Maps API key. Defaults to None.
+        **kwargs: Additional arguments to pass to ipyleaflet.TileLayer().
+    """
+
+    allow_types = ["ROADMAP", "SATELLITE", "HYBRID", "TERRAIN"]
+    if map_type not in allow_types:
+        print("map_type must be one of the following: {}".format(allow_types))
+        return
+
+    if api_key is None:
+        api_key = os.environ.get("GOOGLE_MAPS_API_KEY", "")
+
+    if api_key == "":
+        MAP_TILES = {
+            "ROADMAP": {
+                "url": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}",
+                "attribution": "Esri",
+                "name": "Esri.WorldStreetMap",
+            },
+            "SATELLITE": {
+                "url": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+                "attribution": "Esri",
+                "name": "Esri.WorldImagery",
+            },
+            "TERRAIN": {
+                "url": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}",
+                "attribution": "Esri",
+                "name": "Esri.WorldTopoMap",
+            },
+            "HYBRID": {
+                "url": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+                "attribution": "Esri",
+                "name": "Esri.WorldImagery",
+            },
+        }
+
+        print(
+            "Google Maps API key is required to use Google Maps. You can generate one from https://bit.ly/3sw0THG and use geemap.set_api_key(), defaulting to Esri basemaps."
+        )
+
+    else:
+        MAP_TILES = {
+            "ROADMAP": {
+                "url": f"https://mt1.google.com/vt/lyrs=m&x={{x}}&y={{y}}&z={{z}}&key={api_key}",
+                "attribution": "Google",
+                "name": "Google Maps",
+            },
+            "SATELLITE": {
+                "url": f"https://mt1.google.com/vt/lyrs=s&x={{x}}&y={{y}}&z={{z}}&key={api_key}",
+                "attribution": "Google",
+                "name": "Google Satellite",
+            },
+            "TERRAIN": {
+                "url": f"https://mt1.google.com/vt/lyrs=p&x={{x}}&y={{y}}&z={{z}}&key={api_key}",
+                "attribution": "Google",
+                "name": "Google Terrain",
+            },
+            "HYBRID": {
+                "url": f"https://mt1.google.com/vt/lyrs=y&x={{x}}&y={{y}}&z={{z}}&key={api_key}",
+                "attribution": "Google",
+                "name": "Google Hybrid",
+            },
+        }
+
+    if "max_zoom" not in kwargs:
+        kwargs["max_zoom"] = 24
+
+    if backend == "ipyleaflet":
+        import ipyleaflet
+
+        layer = ipyleaflet.TileLayer(
+            url=MAP_TILES[map_type]["url"],
+            name=MAP_TILES[map_type]["name"],
+            attribution=MAP_TILES[map_type]["attribution"],
+            visible=show,
+            **kwargs,
+        )
+    elif backend == "folium":
+        import folium
+
+        layer = folium.TileLayer(
+            tiles=MAP_TILES[map_type]["url"],
+            name=MAP_TILES[map_type]["name"],
+            attr=MAP_TILES[map_type]["attribution"],
+            overlay=True,
+            control=True,
+            show=show,
+            **kwargs,
+        )
+    else:
+        raise ValueError("backend must be either 'ipyleaflet' or 'folium'")
+
+    return layer

--- a/geemap/foliumap.py
+++ b/geemap/foliumap.py
@@ -78,7 +78,7 @@ class Map(folium.Map):
             kwargs["max_zoom"] = 30
 
         if "add_google_map" not in kwargs.keys() and "basemap" not in kwargs.keys():
-            kwargs["add_google_map"] = True
+            kwargs["add_google_map"] = False
         if "plugin_LatLngPopup" not in kwargs.keys():
             kwargs["plugin_LatLngPopup"] = False
         if "plugin_Fullscreen" not in kwargs.keys():
@@ -182,14 +182,18 @@ class Map(folium.Map):
 
     set_options = setOptions
 
-    def add_basemap(self, basemap="HYBRID"):
+    def add_basemap(self, basemap="HYBRID", **kwargs):
         """Adds a basemap to the map.
 
         Args:
             basemap (str, optional): Can be one of string from ee_basemaps. Defaults to 'HYBRID'.
         """
         try:
-            basemaps[basemap].add_to(self)
+            if basemap in ["ROADMAP", "SATELLITE", "HYBRID", "TERRAIN"]:
+                layer = get_google_map(basemap, backend="folium", **kwargs)
+                layer.add_to(self)
+            else:
+                basemaps[basemap].add_to(self)
         except Exception:
             raise Exception(
                 "Basemap can only be one of the following: {}".format(
@@ -1692,9 +1696,9 @@ class Map(folium.Map):
         max_width=200,
         layer_name="Markers",
         icon=None,
-        icon_shape='circle-dot',
+        icon_shape="circle-dot",
         border_width=3,
-        border_color='#0000ff',
+        border_color="#0000ff",
         **kwargs,
     ):
         """Adds markers to the map from a csv or Pandas DataFrame containing x, y values.

--- a/geemap/foliumap.py
+++ b/geemap/foliumap.py
@@ -182,18 +182,31 @@ class Map(folium.Map):
 
     set_options = setOptions
 
-    def add_basemap(self, basemap="HYBRID", **kwargs):
+    def add_basemap(self, basemap="ROADMAP", **kwargs):
         """Adds a basemap to the map.
 
         Args:
-            basemap (str, optional): Can be one of string from ee_basemaps. Defaults to 'HYBRID'.
+            basemap (str, optional): Can be one of string from ee_basemaps. Defaults to 'ROADMAP'.
         """
         try:
-            if basemap in ["ROADMAP", "SATELLITE", "HYBRID", "TERRAIN"]:
-                layer = get_google_map(basemap, backend="folium", **kwargs)
-                layer.add_to(self)
-            else:
-                basemaps[basemap].add_to(self)
+            map_dict = {
+                "ROADMAP": "Esri.WorldStreetMap",
+                "SATELLITE": "Esri.WorldImagery",
+                "TERRAIN": "Esri.WorldTopoMap",
+                "HYBRID": "Esri.WorldImagery",
+            }
+
+            if isinstance(basemap, str):
+                if basemap.upper() in map_dict:
+                    if basemap in os.environ:
+                        if "name" in kwargs:
+                            kwargs["name"] = basemap
+                        basemap = os.environ[basemap]
+                        self.add_tile_layer(tiles=basemap, **kwargs)
+
+                    else:
+                        basemap = basemap.upper()
+                        basemaps[basemap].add_to(self)
         except Exception:
             raise Exception(
                 "Basemap can only be one of the following: {}".format(

--- a/geemap/geemap.py
+++ b/geemap/geemap.py
@@ -567,11 +567,11 @@ class Map(ipyleaflet.Map):
 
     getScale = get_scale
 
-    def add_basemap(self, basemap="HYBRID", show=True, **kwargs):
+    def add_basemap(self, basemap="ROADMAP", show=True, **kwargs):
         """Adds a basemap to the map.
 
         Args:
-            basemap (str, optional): Can be one of string from basemaps. Defaults to 'HYBRID'.
+            basemap (str, optional): Can be one of string from basemaps. Defaults to 'ROADMAP'.
             visible (bool, optional): Whether the basemap is visible or not. Defaults to True.
             **kwargs: Keyword arguments for the TileLayer.
         """
@@ -581,17 +581,20 @@ class Map(ipyleaflet.Map):
             layer_names = self.get_layer_names()
 
             map_dict = {
-                "ROADMAP": "Google Maps",
-                "SATELLITE": "Google Satellite",
-                "TERRAIN": "Google Terrain",
-                "HYBRID": "Google Hybrid",
+                "ROADMAP": "Esri.WorldStreetMap",
+                "SATELLITE": "Esri.WorldImagery",
+                "TERRAIN": "Esri.WorldTopoMap",
+                "HYBRID": "Esri.WorldImagery",
             }
 
             if isinstance(basemap, str):
                 if basemap.upper() in map_dict:
-                    layer = get_google_map(basemap.upper(), **kwargs)
-                    self.add(layer)
-                    return
+                    if basemap in os.environ:
+                        if "name" in kwargs:
+                            kwargs["name"] = basemap
+                        basemap = os.environ[basemap]
+                    else:
+                        basemap = map_dict[basemap.upper()]
 
             if isinstance(basemap, xyzservices.TileProvider):
                 name = basemap.name
@@ -617,6 +620,8 @@ class Map(ipyleaflet.Map):
                 arc_add_layer(basemaps[basemap].url, basemap)
             elif basemap in basemaps and basemaps[basemap].name in layer_names:
                 print(f"{basemap} has been already added before.")
+            elif basemap.startswith("http"):
+                self.add_tile_layer(url=basemap, shown=show, **kwargs)
             else:
                 print(
                     "Basemap can only be one of the following:\n  {}".format(
@@ -3482,14 +3487,14 @@ class Map(ipyleaflet.Map):
             return
 
         left_layer = ipyleaflet.TileLayer(
-            url="https://mt1.google.com/vt/lyrs=m&x={x}&y={y}&z={z}",
-            attribution="Google",
-            name="Google Maps",
+            url="https://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}",
+            attribution="Esri",
+            name="Esri.WorldStreetMap",
         )
         right_layer = ipyleaflet.TileLayer(
-            url="https://mt1.google.com/vt/lyrs=m&x={x}&y={y}&z={z}",
-            attribution="Google",
-            name="Google Maps",
+            url="https://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}",
+            attribution="Esri",
+            name="Esri.WorldStreetMap",
         )
 
         self.clear_controls()

--- a/geemap/geemap.py
+++ b/geemap/geemap.py
@@ -239,8 +239,8 @@ class Map(ipyleaflet.Map):
                 self.sandbox_path = None
 
         # Add Google Maps as the default basemap
-        if kwargs.get("add_google_map", True):
-            self.add("Google Maps")
+        if kwargs.get("add_google_map", False):
+            self.add_basemap("ROADMAP")
 
         # Remove all default controls
         self.clear_controls()
@@ -589,7 +589,9 @@ class Map(ipyleaflet.Map):
 
             if isinstance(basemap, str):
                 if basemap.upper() in map_dict:
-                    basemap = map_dict[basemap.upper()]
+                    layer = get_google_map(basemap.upper(), **kwargs)
+                    self.add(layer)
+                    return
 
             if isinstance(basemap, xyzservices.TileProvider):
                 name = basemap.name


### PR DESCRIPTION
This PR updates the Google Maps API key requirement. Users first need to get a Google Maps API key from [https://bit.ly/3sw0THG](https://bit.ly/3sw0THG). Then, set the environment variable using `geemap.set_api_key(<API-KEY>)`

If `GOOGLE_MAPS_API_KEY` is not detected in the environment variables, then defaults to Esri basemaps. This provides backward compability. 

Here are some senarios how the basemaps are handled:

**Senario 1:** If `GOOGLE_MAPS_API_KEY` is not detected  in the environmet variables, the OpenStreetMap will be used by default. No warning message is shown.
```python
import geemap
Map = geemap.Map()
Map
```
![image](https://github.com/gee-community/geemap/assets/5016453/81f92723-0f74-43d6-adcf-80e96835a046)

**Senario 2:** If `GOOGLE_MAPS_API_KEY` is not detected  in the environmet variables and users use `add_basemap()` to add Google Maps, a warning message will be shown and the corresponding Esri basemap will be used. 

> Google Maps API key is required to use Google Maps. You can generate one from https://bit.ly/3sw0THG and use geemap.set_api_key(), defaulting to Esri basemaps.


- "ROADMAP" -> "Esri.WorldStreetMap"
- "SATELLITE" -> "Esri.WorldImagery"
- "TERRAIN": "Esri.WorldTopoMap"
- "HYBRID": "Esri.WorldImagery"

```python
Map.add_basemap("ROADMAP")
```
![image](https://github.com/gee-community/geemap/assets/5016453/926d37a7-0b68-4f74-b8fa-2e210e419dc0)

```python
Map.add_basemap("SATELLITE")
```
![image](https://github.com/gee-community/geemap/assets/5016453/4ee9b462-02ef-46b5-9483-52fb47486546)

```python
Map.add_basemap("TERRAIN")
```
![image](https://github.com/gee-community/geemap/assets/5016453/9f3975d5-d2ce-463d-8c05-ff26e1681d5c)

```python
Map.add_basemap("HYBRID")
```
![image](https://github.com/gee-community/geemap/assets/5016453/4ee9b462-02ef-46b5-9483-52fb47486546)

**Senario 3:** If `GOOGLE_MAPS_API_KEY` is detected in the environmet variables, then Google Maps can be added as usual.

```python
import geemap
geemap.set_api_key(<API-KEY>)
Map = geemap.Map()
Map.add_basemap("HYBRID")
Map
```
![image](https://github.com/gee-community/geemap/assets/5016453/e316e491-f00a-4bda-aefd-f293cdad6b84)

@jdbcode @naschmitz 
