### PR TITLE
Clean up layer management ivars.

### DIFF
--- a/examples/notebooks/select_features.ipynb
+++ b/examples/notebooks/select_features.ipynb
@@ -122,7 +122,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "# Map.remove_layer(layer)"
+                "Map.remove_layer(layer)"
             ]
         },
         {
@@ -140,7 +140,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "del layer"
+                "# del layer"
             ]
         },
         {
@@ -200,7 +200,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map.ee_layer_dict"
+                "Map.ee_layers"
             ]
         },
         {
@@ -222,7 +222,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "\n",
                 "states = ee.FeatureCollection('TIGER/2018/States')\n",
                 "\n",
@@ -246,7 +246,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "\n",
                 "states = ee.FeatureCollection('TIGER/2018/States')\n",
                 "image = ee.Image().paint(states, 0, 2)\n",
@@ -273,7 +273,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "\n",
                 "tn = ee.FeatureCollection('TIGER/2018/States').filter(ee.Filter.eq(\"NAME\", 'Tennessee'))\n",
                 "\n",
@@ -313,7 +313,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "\n",
                 "selected = ee.FeatureCollection('TIGER/2018/States').filter(\n",
                 "    ee.Filter.inList(\"NAME\", ['Tennessee', 'Alabama', 'Georgia'])\n",
@@ -439,7 +439,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "\n",
                 "states = ee.FeatureCollection('TIGER/2018/States')\n",
                 "\n",
@@ -570,7 +570,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "\n",
                 "dataset = ee.FeatureCollection('TIGER/2010/Blocks').filter(\n",
                 "    ee.Filter.eq('statefp10', '47')\n",
@@ -616,7 +616,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "\n",
                 "Map.setCenter(-110, 40, 5)\n",
                 "states = ee.FeatureCollection('TIGER/2018/States')\n",
@@ -665,7 +665,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "\n",
                 "dataset = ee.FeatureCollection('TIGER/2010/Tracts_DP1')\n",
                 "visParams = {\n",
@@ -717,7 +717,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "\n",
                 "fc = ee.FeatureCollection('TIGER/2016/Roads')\n",
                 "Map.setCenter(-73.9596, 40.7688, 12)\n",
@@ -740,6 +740,18 @@
             "display_name": "Python 3",
             "language": "python",
             "name": "python3"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.11.4"
         }
     },
     "nbformat": 4,

--- a/geemap/map_widgets.py
+++ b/geemap/map_widgets.py
@@ -304,10 +304,10 @@ class Inspector(ipywidgets.VBox):
         if self._names is not None:
             names = [names] if isinstance(names, str) else self._names
             for name in names:
-                if name in self._host_map.ee_layer_names:
-                    layers[name] = self._host_map.ee_layer_dict[name]
+                if name in self._host_map.ee_layers:
+                    layers[name] = self._host_map.ee_layers[name]
         else:
-            layers = self._host_map.ee_layer_dict
+            layers = self._host_map.ee_layers
         return {k: v for k, v in layers.items() if v["ee_layer"].visible}
 
     def _root_node(self, title, nodes, **kwargs):
@@ -774,10 +774,10 @@ class LayerManager(ipywidgets.VBox):
             layer.visible = change["new"]
 
         layer_name = change["owner"].description
-        if layer_name not in self._host_map.ee_layer_names:
+        if layer_name not in self._host_map.ee_layers:
             return
 
-        layer_dict = self._host_map.ee_layer_dict[layer_name]
+        layer_dict = self._host_map.ee_layers[layer_name]
         for attachment_name in ["legend", "colorbar"]:
             attachment = layer_dict.get(attachment_name, None)
             attachment_on_map = attachment in self._host_map.controls

--- a/geemap/toolbar.py
+++ b/geemap/toolbar.py
@@ -204,7 +204,7 @@ class Toolbar(widgets.VBox):
 
             def _on_open_vis(layer_name):
                 self.host_map.create_vis_widget(
-                    self.host_map.ee_layer_dict.get(layer_name, None)
+                    self.host_map.ee_layers.get(layer_name, None)
                 )
 
             self.host_map.layer_manager_widget = map_widgets.LayerManager(self.host_map)
@@ -666,9 +666,7 @@ def ee_plot_gui(m, position="topright", **kwargs):
     )
 
     m._plot_checked = True
-    dropdown = widgets.Dropdown(
-        options=list(m.ee_raster_layer_names),
-    )
+    dropdown = widgets.Dropdown(options=list(m.ee_raster_layers.keys()))
     dropdown.layout.width = "18ex"
     m._plot_dropdown_widget = dropdown
 
@@ -697,10 +695,7 @@ def ee_plot_gui(m, position="topright", **kwargs):
             and len(m.ee_raster_layers) > 0
         ):
             plot_layer_name = m._plot_dropdown_widget.value
-            layer_names = m.ee_raster_layer_names
-            layers = m.ee_raster_layers
-            index = layer_names.index(plot_layer_name)
-            ee_object = layers[index]
+            ee_object = m.ee_layers.get(plot_layer_name)["ee_object"]
 
             if isinstance(ee_object, ee.ImageCollection):
                 ee_object = ee_object.mosaic()
@@ -2791,7 +2786,7 @@ def time_slider(m=None):
     col_options = list(col_options_dict.keys())
 
     if m is not None:
-        col_options += m.ee_raster_layer_names
+        col_options += m.ee_raster_layers.keys()
 
     collection = widgets.Dropdown(
         options=col_options,
@@ -2802,7 +2797,7 @@ def time_slider(m=None):
     )
 
     region = widgets.Dropdown(
-        options=["User-drawn ROI"] + m.ee_vector_layer_names,
+        options=["User-drawn ROI"] + m.ee_vector_layers.keys(),
         value="User-drawn ROI",
         description="Region:",
         layout=widgets.Layout(width=widget_width, padding=padding),
@@ -3205,8 +3200,8 @@ def time_slider(m=None):
                 with output:
                     print("Use the Drawing tool to create an ROI.")
                     return
-            elif region.value in m.ee_layer_dict:
-                roi = m.ee_layer_dict[region.value]["ee_object"]
+            elif region.value in m.ee_layers:
+                roi = m.ee_layers[region.value]["ee_object"]
 
             with output:
                 print("Computing... Please wait...")
@@ -3254,8 +3249,8 @@ def time_slider(m=None):
                 except Exception as e:
                     raise ValueError(e)
 
-            if collection.value in m.ee_raster_layer_names:
-                layer = m.ee_layer_dict[collection.value]
+            if collection.value in m.ee_raster_layers:
+                layer = m.ee_layers[collection.value]
                 ee_object = layer["ee_object"]
             elif collection.value in col_options_dict:
                 start_date = str(start_month.value).zfill(2) + "-01"
@@ -3362,13 +3357,13 @@ def time_slider(m=None):
     def collection_changed(change):
         if change["new"]:
             selected = change["owner"].value
-            if selected in m.ee_layer_dict:
+            if selected in m.ee_layers:
                 prebuilt_options.children = []
                 labels.value = ""
                 region.value = None
 
-                ee_object = m.ee_layer_dict[selected]["ee_object"]
-                vis_params = m.ee_layer_dict[selected]["vis_params"]
+                ee_object = m.ee_layers[selected]["ee_object"]
+                vis_params = m.ee_layers[selected]["vis_params"]
                 if isinstance(ee_object, ee.Image):
                     palette_vbox.children = [
                         widgets.HBox([classes, colormap]),
@@ -3703,10 +3698,10 @@ def plot_transect(m=None):
     )
 
     if m is not None:
-        layer.options = m.ee_raster_layer_names
+        layer.options = m.ee_raster_layers.keys()
         layer.value = layer.options[0]
         if len(layer.options) > 0:
-            image = m.ee_layer_dict[layer.value]["ee_object"]
+            image = m.ee_layers[layer.value]["ee_object"]
             if isinstance(image, ee.ImageCollection):
                 image = image.toBands()
             band.options = image.bandNames().getInfo()
@@ -3720,7 +3715,7 @@ def plot_transect(m=None):
     def layer_changed(change):
         if change["new"]:
             if m is not None:
-                image = m.ee_layer_dict[layer.value]["ee_object"]
+                image = m.ee_layers[layer.value]["ee_object"]
                 if isinstance(image, ee.ImageCollection):
                     image = image.toBands()
                 band.options = image.bandNames().getInfo()
@@ -3775,7 +3770,7 @@ def plot_transect(m=None):
                         if geom_type != "LineString":
                             print("Use drawing tool to draw a line")
                         else:
-                            image = m.ee_layer_dict[layer.value]["ee_object"]
+                            image = m.ee_layers[layer.value]["ee_object"]
                             if isinstance(image, ee.ImageCollection):
                                 image = image.toBands()
                             image = image.select([band.value])
@@ -3980,10 +3975,10 @@ def sankee_gui(m=None):
     )
 
     if m is not None:
-        if "Las Vegas" not in m.ee_vector_layer_names:
-            region.options = ["User-drawn ROI", "Las Vegas"] + m.ee_vector_layer_names
+        if "Las Vegas" not in m.ee_vector_layers.keys():
+            region.options = ["User-drawn ROI", "Las Vegas"] + m.ee_vector_layers.keys()
         else:
-            region.options = ["User-drawn ROI"] + m.ee_vector_layer_names
+            region.options = ["User-drawn ROI"] + m.ee_vector_layers.keys()
 
         plot_close_btn = widgets.Button(
             tooltip="Close the plot",
@@ -4201,7 +4196,7 @@ def sankee_gui(m=None):
                         image1 = image1.clip(geom)
                         image2 = image2.clip(geom)
                     else:
-                        roi_object = m.ee_layer_dict[region.value]["ee_object"]
+                        roi_object = m.ee_layers[region.value]["ee_object"]
                         if region.value == "Las Vegas":
                             m.centerObject(roi_object, 10)
                         if isinstance(roi_object, ee.Geometry):

--- a/tests/fake_map.py
+++ b/tests/fake_map.py
@@ -7,8 +7,7 @@ class FakeMap:
         self.scale = 1024
         self.zoom = 7
         self.layers = []
-        self.ee_layer_dict = {}
-        self.layers = []
+        self.ee_layers = {}
         self.geojson_layers = []
 
         self._recognized_attrs = self.__dict__.keys()

--- a/tests/test_map_widgets.py
+++ b/tests/test_map_widgets.py
@@ -365,7 +365,7 @@ class TestInspector(unittest.TestCase):
 
     def test_map_click(self):
         """Tests that clicking the map triggers inspection."""
-        self.map_fake.ee_layer_dict = {
+        self.map_fake.ee_layers = {
             "test-map-1": {
                 "ee_object": ee.Image(1),
                 "ee_layer": fake_map.FakeEeTileLayer(visible=True),
@@ -410,7 +410,7 @@ class TestInspector(unittest.TestCase):
 
     def test_map_click_twice(self):
         """Tests that clicking the map a second time removes the original output."""
-        self.map_fake.ee_layer_dict = {
+        self.map_fake.ee_layers = {
             "test-map-1": {
                 "ee_object": ee.Image(1),
                 "ee_layer": fake_map.FakeEeTileLayer(visible=True),
@@ -494,7 +494,7 @@ class TestLayerManager(unittest.TestCase):
                 style={"some-style": "red", "opacity": 0.3, "fillOpacity": 0.2},
             ),
         ]
-        self.fake_map.ee_layer_dict = {
+        self.fake_map.ee_layers = {
             "test-layer": {
                 "ee_object": None,
                 "ee_layer": self.fake_map.layers[2],

--- a/tutorials/FeatureCollection/us_census_data.ipynb
+++ b/tutorials/FeatureCollection/us_census_data.ipynb
@@ -91,7 +91,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "\n",
                 "states = ee.FeatureCollection('TIGER/2018/States')\n",
                 "\n",
@@ -115,7 +115,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "\n",
                 "states = ee.FeatureCollection('TIGER/2018/States')\n",
                 "image = ee.Image().paint(states, 0, 2)\n",
@@ -142,7 +142,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "\n",
                 "tn = ee.FeatureCollection('TIGER/2018/States').filter(ee.Filter.eq(\"NAME\", 'Tennessee'))\n",
                 "\n",
@@ -184,7 +184,7 @@
             },
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "\n",
                 "selected = ee.FeatureCollection('TIGER/2018/States').filter(\n",
                 "    ee.Filter.inList(\"NAME\", ['Tennessee', 'Alabama', 'Georgia'])\n",
@@ -310,7 +310,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "\n",
                 "states = ee.FeatureCollection('TIGER/2018/States')\n",
                 "\n",
@@ -441,7 +441,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "\n",
                 "dataset = ee.FeatureCollection('TIGER/2010/Blocks').filter(\n",
                 "    ee.Filter.eq('statefp10', '47')\n",
@@ -487,7 +487,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "\n",
                 "Map.setCenter(-110, 40, 5)\n",
                 "states = ee.FeatureCollection('TIGER/2018/States')\n",
@@ -536,7 +536,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "\n",
                 "dataset = ee.FeatureCollection('TIGER/2010/Tracts_DP1')\n",
                 "visParams = {\n",
@@ -588,7 +588,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "\n",
                 "fc = ee.FeatureCollection('TIGER/2016/Roads')\n",
                 "Map.setCenter(-73.9596, 40.7688, 12)\n",

--- a/tutorials/Image/01_image_overview.ipynb
+++ b/tutorials/Image/01_image_overview.ipynb
@@ -78,7 +78,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "Map.add_basemap('ROADMAP')  # Add Google Map\n",
                 "Map"
             ]

--- a/tutorials/Image/02_image_visualization.ipynb
+++ b/tutorials/Image/02_image_visualization.ipynb
@@ -97,7 +97,7 @@
             },
             "outputs": [],
             "source": [
-                "Map = emap.Map()\n",
+                "Map = geemap.Map()\n",
                 "\n",
                 "# Load an image.\n",
                 "image = ee.Image('LANDSAT/LC08/C01/T1_TOA/LC08_044034_20140318')\n",
@@ -133,7 +133,7 @@
             "outputs": [],
             "source": [
                 "# Create a default map\n",
-                "Map = emap.Map()\n",
+                "Map = geemap.Map()\n",
                 "\n",
                 "# Load an image.\n",
                 "image = ee.Image('LANDSAT/LC08/C01/T1_TOA/LC08_044034_20140318')\n",
@@ -175,7 +175,7 @@
             "outputs": [],
             "source": [
                 "# Create a default map\n",
-                "Map = emap.Map()\n",
+                "Map = geemap.Map()\n",
                 "\n",
                 "# Load an image.\n",
                 "image = ee.Image('LANDSAT/LC08/C01/T1_TOA/LC08_044034_20140318')\n",
@@ -214,7 +214,7 @@
             "outputs": [],
             "source": [
                 "# Create a default map\n",
-                "Map = emap.Map()\n",
+                "Map = geemap.Map()\n",
                 "\n",
                 "# Load an image.\n",
                 "image = ee.Image('LANDSAT/LC08/C01/T1_TOA/LC08_044034_20140318')\n",
@@ -257,7 +257,7 @@
             "outputs": [],
             "source": [
                 "# Create a default map\n",
-                "Map = emap.Map()\n",
+                "Map = geemap.Map()\n",
                 "\n",
                 "# Load an image.\n",
                 "image = ee.Image('LANDSAT/LC08/C01/T1_TOA/LC08_044034_20140318')\n",
@@ -311,7 +311,7 @@
             "outputs": [],
             "source": [
                 "# Create a default map\n",
-                "Map = emap.Map()\n",
+                "Map = geemap.Map()\n",
                 "\n",
                 "# Load an image.\n",
                 "image = ee.Image('LANDSAT/LC08/C01/T1_TOA/LC08_044034_20140318')\n",
@@ -369,7 +369,7 @@
             "outputs": [],
             "source": [
                 "# Create a default map\n",
-                "Map = emap.Map()\n",
+                "Map = geemap.Map()\n",
                 "\n",
                 "# Load an image.\n",
                 "image = ee.Image('LANDSAT/LC08/C01/T1_TOA/LC08_044034_20140318')\n",
@@ -432,7 +432,7 @@
             "outputs": [],
             "source": [
                 "# Create a default map\n",
-                "Map = emap.Map()\n",
+                "Map = geemap.Map()\n",
                 "\n",
                 "# Load 2012 MODIS land cover and select the IGBP classification.\n",
                 "cover = ee.Image('MODIS/051/MCD12Q1/2012_01_01').select('Land_Cover_Type_1')\n",

--- a/tutorials/Image/03_image_metadata.ipynb
+++ b/tutorials/Image/03_image_metadata.ipynb
@@ -76,7 +76,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "Map.add_basemap('ROADMAP')  # Add Google Map\n",
                 "Map"
             ]

--- a/tutorials/Image/04_math_operations.ipynb
+++ b/tutorials/Image/04_math_operations.ipynb
@@ -76,7 +76,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "Map.add_basemap('ROADMAP')  # Add Google Map\n",
                 "Map"
             ]
@@ -188,7 +188,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)"
+                "Map = geemap.Map(center=[40, -100], zoom=4)"
             ]
         },
         {

--- a/tutorials/Image/05_conditional_operations.ipynb
+++ b/tutorials/Image/05_conditional_operations.ipynb
@@ -76,7 +76,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "Map.add_basemap('ROADMAP')  # Add Google Map\n",
                 "Map"
             ]
@@ -129,7 +129,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map()\n",
+                "Map = geemap.Map()\n",
                 "\n",
                 "# Load a 2012 nightlights image.\n",
                 "nl2012 = ee.Image('NOAA/DMSP-OLS/NIGHTTIME_LIGHTS/F182012')\n",
@@ -163,7 +163,7 @@
             },
             "outputs": [],
             "source": [
-                "Map = emap.Map()\n",
+                "Map = geemap.Map()\n",
                 "\n",
                 "# Create zones using an expression, display.\n",
                 "zonesExp = nl2012.expression(\n",
@@ -196,7 +196,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map()\n",
+                "Map = geemap.Map()\n",
                 "\n",
                 "# Load a cloudy Landsat 8 image.\n",
                 "image = ee.Image('LANDSAT/LC08/C01/T1_TOA/LC08_044034_20130603')\n",

--- a/tutorials/Image/06_convolutions.ipynb
+++ b/tutorials/Image/06_convolutions.ipynb
@@ -76,7 +76,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "Map.add_basemap('ROADMAP')  # Add Google Map\n",
                 "Map"
             ]
@@ -129,7 +129,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "\n",
                 "# Define a Laplacian, or edge-detection kernel.\n",
                 "laplacian = ee.Kernel.laplacian8(1, False)\n",

--- a/tutorials/Image/07_morphological_operations.ipynb
+++ b/tutorials/Image/07_morphological_operations.ipynb
@@ -76,7 +76,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "Map.add_basemap('ROADMAP')  # Add Google Map\n",
                 "Map"
             ]

--- a/tutorials/Image/08_gradients.ipynb
+++ b/tutorials/Image/08_gradients.ipynb
@@ -76,7 +76,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "Map.add_basemap('ROADMAP')  # Add Google Map\n",
                 "Map"
             ]

--- a/tutorials/Image/09_edge_detection.ipynb
+++ b/tutorials/Image/09_edge_detection.ipynb
@@ -76,7 +76,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "Map.add_basemap('ROADMAP')  # Add Google Map\n",
                 "Map"
             ]

--- a/tutorials/Image/10_spectral_transformations.ipynb
+++ b/tutorials/Image/10_spectral_transformations.ipynb
@@ -76,7 +76,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "Map.add_basemap('ROADMAP')  # Add Google Map\n",
                 "Map"
             ]
@@ -133,7 +133,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "\n",
                 "bands = ['B1', 'B2', 'B3', 'B4', 'B5', 'B6', 'B7']\n",
                 "image = ee.Image('LANDSAT/LT05/C01/T1/LT05_044034_20080214').select(bands)\n",

--- a/tutorials/Image/11_texture.ipynb
+++ b/tutorials/Image/11_texture.ipynb
@@ -76,7 +76,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "Map.add_basemap('ROADMAP')  # Add Google Map\n",
                 "Map"
             ]

--- a/tutorials/Image/12_object_based_methods.ipynb
+++ b/tutorials/Image/12_object_based_methods.ipynb
@@ -94,7 +94,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "Map.add_basemap('ROADMAP')  # Add Google Map\n",
                 "Map"
             ]

--- a/tutorials/Image/13_cumulative_cost_mapping.ipynb
+++ b/tutorials/Image/13_cumulative_cost_mapping.ipynb
@@ -78,7 +78,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "Map.add_basemap('ROADMAP')  # Add Google Map\n",
                 "Map"
             ]

--- a/tutorials/Image/14_registering_images.ipynb
+++ b/tutorials/Image/14_registering_images.ipynb
@@ -76,7 +76,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "Map.add_basemap('ROADMAP')  # Add Google Map\n",
                 "Map"
             ]

--- a/tutorials/ImageCollection/01_image_collection_overview.ipynb
+++ b/tutorials/ImageCollection/01_image_collection_overview.ipynb
@@ -76,7 +76,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "Map.add_basemap('ROADMAP')  # Add Google Map\n",
                 "Map"
             ]

--- a/tutorials/ImageCollection/02_image_collection_metadata.ipynb
+++ b/tutorials/ImageCollection/02_image_collection_metadata.ipynb
@@ -76,7 +76,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "Map.add_basemap('ROADMAP')  # Add Google Map\n",
                 "Map"
             ]

--- a/tutorials/ImageCollection/03_filtering_image_collection.ipynb
+++ b/tutorials/ImageCollection/03_filtering_image_collection.ipynb
@@ -76,7 +76,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "Map.add_basemap('ROADMAP')  # Add Google Map\n",
                 "Map"
             ]

--- a/tutorials/ImageCollection/04_mapping_over_image_collection.ipynb
+++ b/tutorials/ImageCollection/04_mapping_over_image_collection.ipynb
@@ -76,7 +76,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "Map.add_basemap('ROADMAP')  # Add Google Map\n",
                 "Map"
             ]
@@ -216,7 +216,7 @@
                 "\n",
                 "vizParams = {'bands': ['B5', 'B4', 'B3'], 'min': 0, 'max': 0.4}\n",
                 "\n",
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "\n",
                 "\n",
                 "Map.centerObject(point, 8)\n",
@@ -260,7 +260,7 @@
                 "\n",
                 "vizParams = {'bands': ['B5', 'B4', 'B3'], 'min': 0, 'max': 0.4}\n",
                 "\n",
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "\n",
                 "\n",
                 "Map.centerObject(point, 8)\n",

--- a/tutorials/Template/template.ipynb
+++ b/tutorials/Template/template.ipynb
@@ -68,7 +68,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "Map = emap.Map(center=[40, -100], zoom=4)\n",
+                "Map = geemap.Map(center=[40, -100], zoom=4)\n",
                 "Map.add_basemap('ROADMAP')  # Add Google Map\n",
                 "Map"
             ]


### PR DESCRIPTION
Renamed `ee_layer_dict` to `ee_layers` and removed `ee_layer_names`, `ee_raster_layer_names`, `ee_vector_layer_names`. Maintained computed properties for backward compatibility.

It's easier to have 1 source of truth for the EE layers. This is slightly less performant, but not enough to justify maintaining multiple extra copies of a dictionary.