### PR TITLE
Fix layer visualization GUI bug

### DIFF
--- a/geemap/map_widgets.py
+++ b/geemap/map_widgets.py
@@ -735,6 +735,7 @@ class LayerManager(ipywidgets.VBox):
         settings_button = ipywidgets.Button(
             icon="gear",
             layout=ipywidgets.Layout(width="25px", height="25px", padding="0px"),
+            tooltip=layer.name,
         )
         settings_button.on_click(self._on_layer_settings_click)
 


### PR DESCRIPTION
Fix #1686 

The refactoring in #1671 added the following function to invoke the layer visualization GUI. However, `button.tooltip` was not initialized when creating buttons, resulting in no action when the button is clicked. This PR fixes this bug. 

@naschmitz 

```python
    def _on_layer_settings_click(self, button):
        if self.on_open_vis:
            self.on_open_vis(button.tooltip)
```

![Peek 2023-08-31 13-30](https://github.com/gee-community/geemap/assets/5016453/5fdb02c3-7d6c-43a3-b2c5-e246ce44e2e6)
