### PR TITLE
`ee_to_df` Make prop names and col names same

### DIFF
--- a/geemap/common.py
+++ b/geemap/common.py
@@ -8918,12 +8918,13 @@ def ee_to_df(ee_object, col_names=None, sort_columns=False, **kwargs):
         raise TypeError("ee_object must be an ee.FeatureCollection")
 
     try:
-        data = ee_object.map(lambda f: ee.Feature(None, f.toDictionary()))
+        property_names = ee_object.first().propertyNames().sort().getInfo()
+        data = ee_object.map(lambda f: ee.Feature(None, f.toDictionary(property_names)))
         data = [x["properties"] for x in data.getInfo()["features"]]
         df = pd.DataFrame(data)
 
         if col_names is None:
-            col_names = ee_object.first().propertyNames().getInfo()
+            col_names = property_names
             col_names.remove("system:index")
         elif not isinstance(col_names, list):
             raise TypeError("col_names must be a list")


### PR DESCRIPTION
In `ee_to_df`, non-geometry features are created using `toDictionary` with the default setting, which excludes non-system properties. Later, when the dataframe is subset by the `col_names` parameter, if the default column names (`None`) is used, column names are fetched from a representative feature using `propertyNames`, which includes system properties. The two lists should be the same to avoid errors.

The fix is to get `propertyNames` and use the variable for both creating features and later subsetting dataframe columns.

This code demonstrates the issue:

```py
import geemap
import ee
ee.Authenticate()
ee.Initialize()

img = ee.Image('LANDSAT/LC08/C02/T1_L2/LC08_044034_20210508')

# sample image and copy image properties to each feature
samp = img.sample(numPixels=10).map(
    lambda feature: feature.copyProperties(img, img.propertyNames()))

df = geemap.ee_to_df(samp)
df
```


