### PR TITLE
Set default add_header to False for add_widget

### DIFF
--- a/geemap/geemap.py
+++ b/geemap/geemap.py
@@ -6155,7 +6155,7 @@ class Map(core.Map):
         self,
         content,
         position="bottomright",
-        add_header=True,
+        add_header=False,
         opened=True,
         show_close_button=True,
         widget_icon="gear",
@@ -6170,7 +6170,7 @@ class Map(core.Map):
         Args:
             content (str | ipywidgets.Widget | object): The widget to add.
             position (str, optional): The position of the widget. Defaults to "bottomright".
-            add_header (bool, optional): Whether to add a header with close buttons to the widget. Defaults to True.
+            add_header (bool, optional): Whether to add a header with close buttons to the widget. Defaults to False.
             opened (bool, optional): Whether to open the toolbar. Defaults to True.
             show_close_button (bool, optional): Whether to show the close button. Defaults to True.
             widget_icon (str, optional): The icon name for the toolbar button. Defaults to 'gear'.

--- a/geemap/geemap.py
+++ b/geemap/geemap.py
@@ -6241,7 +6241,7 @@ class Map(core.Map):
         else:
             raise Exception("Invalid image")
 
-        self.add_widget(image, position=position)
+        self.add_widget(image, position=position, **kwargs)
 
     def add_html(self, html, position="bottomright", **kwargs):
         """Add HTML to the map.


### PR DESCRIPTION

```python
m = geemap.Map(height='400px')
m.add_text('Hello World', add_header=False)
m.add_image('https://i.imgur.com/l9B3gIB.png', add_header=False)
m
```
![image](https://github.com/gee-community/geemap/assets/5016453/3323fc41-035b-4f45-bf5c-052ae81a0aa3)

![image](https://github.com/gee-community/geemap/assets/5016453/e74486ae-855b-4f08-bb33-a2efbdf89154)
