### PR TITLE
Fix map horizontal scrollbar issue

### DIFF
--- a/geemap/core.py
+++ b/geemap/core.py
@@ -163,7 +163,8 @@ class Map(ipyleaflet.Map, MapInterface):
         return self._find_widget_of_type(map_widgets.LayerEditor)
 
     def __init__(self, **kwargs):
-        self.width: str = kwargs.pop("width", "100%")
+        if "width" in kwargs:
+            self.width: str = kwargs.pop("width", "100%")
         self.height: str = kwargs.pop("height", "600px")
 
         self.ee_layers: Dict[str, Dict[str, Any]] = {}


### PR DESCRIPTION
Fix #1725 

This is probably an ipyleaflet bug. Setting `m.layout.width='100%'` adds a horizontal scrollbar to the bottom of the map. By default, if users do not specify the `width` argument, we should not update map width so that the scrollbar does not show up. 

![image](https://github.com/gee-community/geemap/assets/5016453/27355186-cbec-4bf2-bae6-68a2097c29b5)
