### PR TITLE
Fix several bugs and add basemap selector to core.

### DIFF
--- a/geemap/core.py
+++ b/geemap/core.py
@@ -517,7 +517,7 @@ class Map(ipyleaflet.Map, MapInterface):
             ipyleaflet.TileLayer(
                 url=basemap["url"],
                 name=basemap["name"],
-                max_zoom=basemap.get("max_zoom", 22),
+                max_zoom=basemap.get("max_zoom", 24),
                 attribution=basemap.get("attribution", None),
             ),
         )

--- a/geemap/core.py
+++ b/geemap/core.py
@@ -144,22 +144,22 @@ class Map(ipyleaflet.Map, MapInterface):
         self.layout.height = value
 
     @property
-    def _toolbar(self) -> toolbar.Toolbar:
+    def _toolbar(self) -> Optional[toolbar.Toolbar]:
         return self._find_widget_of_type(toolbar.Toolbar)
 
     @property
-    def _inspector(self) -> ipyleaflet.WidgetControl:
+    def _inspector(self) -> Optional[map_widgets.Inspector]:
         return self._find_widget_of_type(map_widgets.Inspector)
 
     @property
-    def _layer_manager(self) -> ipyleaflet.WidgetControl:
+    def _layer_manager(self) -> Optional[map_widgets.LayerManager]:
         if toolbar_widget := self._toolbar:
             if isinstance(toolbar_widget.accessory_widget, map_widgets.LayerManager):
                 return toolbar_widget.accessory_widget
         return self._find_widget_of_type(map_widgets.LayerManager)
 
     @property
-    def _layer_editor(self) -> ipyleaflet.WidgetControl:
+    def _layer_editor(self) -> Optional[map_widgets.LayerEditor]:
         return self._find_widget_of_type(map_widgets.LayerEditor)
 
     def __init__(self, **kwargs):

--- a/geemap/core.py
+++ b/geemap/core.py
@@ -512,15 +512,18 @@ class Map(ipyleaflet.Map, MapInterface):
         if basemap is None:
             logging.warning("Invalid basemap selected: %s", basemap_name)
             return
-        self.substitute_layer(
-            self.layers[0],
-            ipyleaflet.TileLayer(
-                url=basemap["url"],
-                name=basemap["name"],
-                max_zoom=basemap.get("max_zoom", 24),
-                attribution=basemap.get("attribution", None),
-            ),
+        new_layer = ipyleaflet.TileLayer(
+            url=basemap["url"],
+            name=basemap["name"],
+            max_zoom=basemap.get("max_zoom", 24),
+            attribution=basemap.get("attribution", None),
         )
+        # substitute_layer is broken when the map has a single layer.
+        if len(self.layers) == 1:
+            self.clear_layers()
+            self.add_layer(new_layer)
+        else:
+            self.substitute_layer(self.layers[0], new_layer)
 
     def _get_available_basemaps(self) -> Dict[str, Any]:
         """Convert xyz tile services to a dictionary of basemaps."""

--- a/geemap/core.py
+++ b/geemap/core.py
@@ -125,6 +125,7 @@ class Map(ipyleaflet.Map, MapInterface):
         "zoom_control": False,
         "attribution_control": False,
         "ee_initialize": True,
+        "scroll_wheel_zoom": True,
     }
 
     @property
@@ -169,10 +170,6 @@ class Map(ipyleaflet.Map, MapInterface):
 
         self.ee_layers: Dict[str, Dict[str, Any]] = {}
         self.geojson_layers: List[Any] = []
-
-        # Enable scroll wheel zoom by default
-        if "scroll_wheel_zoom" not in kwargs:
-            kwargs["scroll_wheel_zoom"] = True
 
         kwargs = self._apply_kwarg_defaults(kwargs)
         super().__init__(**kwargs)

--- a/geemap/geemap.py
+++ b/geemap/geemap.py
@@ -998,9 +998,10 @@ class Map(core.Map):
             opened (bool, optional): Whether the control is opened. Defaults to True.
             show_close_button (bool, optional): Whether to show the close button. Defaults to True.
         """
-        super()._add_layer_manager("layer_manager", position)
-        self.layer_manager_widget.collapsed = not opened
-        self.layer_manager_widget.close_button_hidden = not show_close_button
+        super()._add_layer_manager(position)
+        if layer_manager := self._layer_manager:
+            layer_manager.collapsed = not opened
+            layer_manager.close_button_hidden = not show_close_button
 
     def add_basemap_widget(
         self,

--- a/geemap/geemap.py
+++ b/geemap/geemap.py
@@ -959,7 +959,7 @@ class Map(core.Map):
         Args:
             layer_dict (dict): A dict containing information about the layer. It is an element from Map.ee_layers.
         """
-        self.add("layer_editor")
+        self._add_layer_editor(position="topright", layer_dict=layer_dict)
 
     def add_inspector(
         self,

--- a/geemap/geemap.py
+++ b/geemap/geemap.py
@@ -196,7 +196,7 @@ class Map(core.Map):
             else:
                 kwargs.pop("basemap")
 
-        self.basemap_control = None
+        self._xyz_dict = get_xyz_dict()
 
         self.baseclass = "ipyleaflet"
         self.kwargs = kwargs
@@ -1003,35 +1003,27 @@ class Map(core.Map):
             layer_manager.collapsed = not opened
             layer_manager.close_button_hidden = not show_close_button
 
-    def add_basemap_widget(
-        self,
-        value="OpenStreetMap",
-        position="topright",
-    ):
+    def _on_basemap_changed(self, basemap_name):
+        if basemap_name not in self.get_layer_names():
+            self.add_basemap(basemap_name)
+            if basemap_name in self._xyz_dict:
+                if "bounds" in self._xyz_dict[basemap_name]:
+                    bounds = self._xyz_dict[basemap_name]["bounds"]
+                    bounds = [bounds[0][1], bounds[0][0], bounds[1][1], bounds[1][0]]
+                    self.zoom_to_bounds(bounds)
+
+    def add_basemap_widget(self, value="OpenStreetMap", position="topright"):
         """Add the Basemap GUI to the map.
 
         Args:
             value (str): The default value from basemaps to select. Defaults to "OpenStreetMap".
             position (str, optional): The position of the Inspector GUI. Defaults to "topright".
         """
-        if self.basemap_control:
-            return
-
-        def _on_close():
-            self.toolbar_reset()
-            if self.basemap_control and self.basemap_control in self.controls:
-                self.remove_control(self.basemap_control)
-                self.basemap_control.close()
-                self.basemap_control = None
-
-        basemap_widget = map_widgets.Basemap(
-            self, list(basemaps.keys()), value, get_xyz_dict()
+        super()._add_basemap_selector(
+            position, basemaps=list(basemaps.keys()), value=value
         )
-        basemap_widget.on_close = _on_close
-        self.basemap_control = ipyleaflet.WidgetControl(
-            widget=basemap_widget, position=position
-        )
-        self.add(self.basemap_control)
+        if basemap_selector := self._basemap_selector:
+            basemap_selector.on_basemap_changed = self._on_basemap_changed
 
     def add_draw_control(self, position="topleft"):
         """Add a draw control to the map

--- a/geemap/map_widgets.py
+++ b/geemap/map_widgets.py
@@ -1021,22 +1021,15 @@ class LayerManager(ipywidgets.VBox):
 class Basemap(ipywidgets.HBox):
     """Widget for selecting a basemap."""
 
-    def __init__(self, host_map, basemaps, value, xyz_services):
+    def __init__(self, basemaps, value):
         """Creates a widget for selecting a basemap.
 
         Args:
-            host_map (geemap.Map): The map to add the basemap widget to.
             basemaps (list): The list of basemap names to make available for selection.
             value (str): The default value from basemaps to select.
-            xyz_services (dict): A dictionary of xyz services for bounds lookup.
         """
-
-        self._host_map = host_map
-        if not host_map:
-            raise ValueError("Must pass a valid map when creating a basemap widget.")
-
-        self._xyz_services = xyz_services
         self.on_close = None
+        self.on_basemap_changed = None
 
         self._dropdown = ipywidgets.Dropdown(
             options=list(basemaps),
@@ -1056,20 +1049,8 @@ class Basemap(ipywidgets.HBox):
         super().__init__([self._dropdown, close_button])
 
     def _on_dropdown_click(self, change):
-        if change["new"]:
-            basemap_name = self._dropdown.value
-            if basemap_name not in self._host_map.get_layer_names():
-                self._host_map.add_basemap(basemap_name)
-                if basemap_name in self._xyz_services:
-                    if "bounds" in self._xyz_services[basemap_name]:
-                        bounds = self._xyz_services[basemap_name]["bounds"]
-                        bounds = [
-                            bounds[0][1],
-                            bounds[0][0],
-                            bounds[1][1],
-                            bounds[1][0],
-                        ]
-                        self._host_map.zoom_to_bounds(bounds)
+        if self.on_basemap_changed and change["new"]:
+            self.on_basemap_changed(self._dropdown.value)
 
     def _on_close_click(self, _):
         if self.on_close:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -135,6 +135,7 @@ class TestMap(unittest.TestCase):
             toolbar_control, ipywidgets.ToggleButton, lambda c: c.tooltip == "Toolbar"
         ).value = True  # Open the grid of tools.
         tool_grid = utils.query_widget(toolbar_control, ipywidgets.GridBox).children
-        self.assertEqual(len(tool_grid), 2)
-        self.assertEqual(tool_grid[0].tooltip, "Inspector")
-        self.assertEqual(tool_grid[1].tooltip, "Get help")
+        self.assertEqual(len(tool_grid), 3)
+        self.assertEqual(tool_grid[0].tooltip, "Basemap selector")
+        self.assertEqual(tool_grid[1].tooltip, "Inspector")
+        self.assertEqual(tool_grid[2].tooltip, "Get help")

--- a/tests/test_map_widgets.py
+++ b/tests/test_map_widgets.py
@@ -235,51 +235,49 @@ class TestLegend(unittest.TestCase):
     TEST_KEYS = ["developed", "forest", "open water"]
 
     def test_legend_unable_to_convert_rgb_to_hex(self):
-        with self.assertRaisesRegex(ValueError,
-                                    "Unable to convert rgb value to hex."):
+        with self.assertRaisesRegex(ValueError, "Unable to convert rgb value to hex."):
             test_keys = ["Key 1"]
             test_colors = [("invalid", "invalid")]
             map_widgets.Legend(keys=test_keys, colors=test_colors)
 
     def test_legend_keys_and_colors_not_same_length(self):
-        with self.assertRaisesRegex(ValueError,
-                                    ("The legend keys and colors must be the "
-                                        + "same length.")):
+        with self.assertRaisesRegex(
+            ValueError, ("The legend keys and colors must be the " + "same length.")
+        ):
             test_keys = ["one", "two", "three", "four"]
-            map_widgets.Legend(keys=test_keys,
-                               colors=TestLegend.TEST_COLORS_HEX)
+            map_widgets.Legend(keys=test_keys, colors=TestLegend.TEST_COLORS_HEX)
 
     def test_legend_builtin_legend_not_allowed(self):
-        expected_regex = ("The builtin legend must be one of the following: {}"
-                          .format(", ".join(builtin_legends)))
+        expected_regex = "The builtin legend must be one of the following: {}".format(
+            ", ".join(builtin_legends)
+        )
         with self.assertRaisesRegex(ValueError, expected_regex):
             map_widgets.Legend(builtin_legend="invalid_builtin_legend")
 
     def test_legend_position_not_allowed(self):
-        expected_regex = ("The position must be one of the following: " +
-                          "topleft, topright, bottomleft, bottomright")
+        expected_regex = (
+            "The position must be one of the following: "
+            + "topleft, topright, bottomleft, bottomright"
+        )
         with self.assertRaisesRegex(ValueError, expected_regex):
             map_widgets.Legend(position="invalid_position")
 
     def test_legend_keys_not_a_dict(self):
-        with self.assertRaisesRegex(TypeError,
-                                    "The legend keys must be a list."):
+        with self.assertRaisesRegex(TypeError, "The legend keys must be a list."):
             map_widgets.Legend(keys="invalid_keys")
 
     def test_legend_colors_not_a_list(self):
-        with self.assertRaisesRegex(TypeError,
-                                    "The legend colors must be a list."):
+        with self.assertRaisesRegex(TypeError, "The legend colors must be a list."):
             map_widgets.Legend(colors="invalid_colors")
 
     def test_legend_colors_not_a_list_of_tuples(self):
-        with self.assertRaisesRegex(TypeError,
-                                    ("The legend colors must be a list of " +
-                                        "tuples.")):
+        with self.assertRaisesRegex(
+            TypeError, ("The legend colors must be a list of " + "tuples.")
+        ):
             map_widgets.Legend(colors=["invalid_tuple"])
 
     def test_legend_dict_not_a_dictionary(self):
-        with self.assertRaisesRegex(TypeError,
-                                    "The legend dict must be a dictionary."):
+        with self.assertRaisesRegex(TypeError, "The legend dict must be a dictionary."):
             map_widgets.Legend(legend_dict="invalid_legend_dict")
 
 
@@ -910,16 +908,9 @@ class TestBasemap(unittest.TestCase):
     """Tests for the Basemap class in the `map_widgets` module."""
 
     def setUp(self):
-        self.map_fake = fake_map.FakeMap()
         self.basemaps = ["first", "default", "bounded"]
         self.default = "default"
-        self.xyz_services = {"bounded": {"bounds": [[2, 1], [4, 3]]}}
-        self.basemap_widget = map_widgets.Basemap(
-            self.map_fake, self.basemaps, self.default, self.xyz_services
-        )
-
-    def tearDown(self):
-        pass
+        self.basemap_widget = map_widgets.Basemap(self.basemaps, self.default)
 
     @property
     def _close_button(self):
@@ -930,22 +921,17 @@ class TestBasemap(unittest.TestCase):
         )
 
     @property
-    def _droopdown(self):
+    def _dropdown(self):
         return utils.query_widget(
             self.basemap_widget, ipywidgets.Dropdown, lambda _: True
         )
 
-    def test_basemap_no_map(self):
-        """Tests that a valid map must be passed in."""
-        with self.assertRaisesRegex(ValueError, "valid map"):
-            map_widgets.Basemap(None, self.basemaps, self.default, self.xyz_services)
-
     def test_basemap(self):
         """Tests that the basemap's initial UI is set up properly."""
         self.assertIsNotNone(self._close_button)
-        self.assertIsNotNone(self._droopdown)
-        self.assertEqual(self._droopdown.value, "default")
-        self.assertEqual(len(self._droopdown.options), 3)
+        self.assertIsNotNone(self._dropdown)
+        self.assertEqual(self._dropdown.value, "default")
+        self.assertEqual(len(self._dropdown.options), 3)
 
     def test_basemap_close(self):
         """Tests that triggering the closing button fires the close event."""
@@ -955,21 +941,14 @@ class TestBasemap(unittest.TestCase):
 
         on_close_mock.assert_called_once()
 
-    @patch.object(fake_map.FakeMap, "zoom_to_bounds")
-    def test_basemap_selection(self, zoom_to_bounds_mock):
-        """Tests that a basemap selection updates the map."""
-        self.assertEqual(self.map_fake.find_layer_index("first"), -1)
-        self.assertEqual(self.map_fake.find_layer_index("bounded"), -1)
+    def test_basemap_selection(self):
+        """Tests that a basemap selection fires the selected event."""
+        on_basemap_changed_mock = Mock()
+        self.basemap_widget.on_basemap_changed = on_basemap_changed_mock
 
-        self._droopdown.value = "first"
-        self.assertEqual(self.map_fake.find_layer_index("first"), 0)
-        self.assertEqual(self.map_fake.find_layer_index("bounded"), -1)
-        zoom_to_bounds_mock.assert_not_called()
+        self._dropdown.value = "first"
 
-        self._droopdown.value = "bounded"
-        self.assertEqual(self.map_fake.find_layer_index("first"), 0)
-        self.assertEqual(self.map_fake.find_layer_index("bounded"), 1)
-        zoom_to_bounds_mock.assert_called_with([1, 2, 3, 4])
+        on_basemap_changed_mock.assert_called_once()
 
 
 @patch.object(ee, "Feature", fake_ee.Feature)


### PR DESCRIPTION
The basemap selector for geemap should be unchanged.

The basemap selector for core actually swaps out `layer[0]`. Users can manually add additional basemap layers if they choose.