### PR TITLE
Revert dark mode changes to toolbar

### DIFF
--- a/geemap/toolbar.py
+++ b/geemap/toolbar.py
@@ -139,10 +139,6 @@ class Toolbar(widgets.VBox):
             layout=widgets.Layout(height="28px", width="72px"),
         )
 
-        if in_colab_shell():
-            self.toolbar_button.button_style = "primary"
-            self.layers_button.button_style = "primary"
-
         self.toolbar_header = widgets.HBox()
         self.toolbar_header.children = [self.layers_button, self.toolbar_button]
         self.toolbar_footer = widgets.VBox()
@@ -838,10 +834,6 @@ def search_data_gui(m, position="topleft"):
         ],
     )
     search_type.style.button_width = "110px"
-
-    if in_colab_shell():
-        search_button.button_style = "primary"
-        search_type.button_style = "primary"
 
     search_box = widgets.Text(
         placeholder="Search by place name or address",


### PR DESCRIPTION
The changes made it really difficult to see the icons in Colab. There isn't enough constrast with these thin icons.

![Icons](https://github.com/gee-community/geemap/assets/12777663/ab8ad9be-1d15-427f-b95f-117e14ccea55)
