### PR TITLE
Fix raster editor bug

### DIFF
--- a/geemap/map_widgets.py
+++ b/geemap/map_widgets.py
@@ -50,6 +50,7 @@ except AttributeError:
 
 class Theme:
     """Applies dynamic theme in Colab, otherwise light."""
+
     current_theme = "colab" if common.in_colab_shell() else "light"
 
     @staticmethod
@@ -1038,7 +1039,10 @@ class _RasterLayerEditor(ipywidgets.VBox):
             self._max_value = self._vis_params["max"]
             self._right_value = 2 * self._max_value
         if "gamma" in self._vis_params.keys():
-            self._layer_gamma = self._vis_params["gamma"]
+            if isinstance(self._vis_params["gamma"], list):
+                self._layer_gamma = self._vis_params["gamma"][0]
+            else:
+                self._layer_gamma = self._vis_params["gamma"]
         if "bands" in self._vis_params.keys():
             self._sel_bands = self._vis_params["bands"]
         if "palette" in self._vis_params.keys():


### PR DESCRIPTION
This PR fixes a RasterEditor bug that throws an error when `gamma` is a list rather than float. 

```python
import ee
import geemap.core as geemap

m = geemap.Map()

image = ee.Image('LANDSAT/LC08/C02/T1_TOA/LC08_044034_20140318').select(
    ['B5', 'B4', 'B3']
)

vis_params = {'min': 0, 'max': 0.5, 'gamma': [0.95, 1.1, 1]}

m.center_object(image)
m.add_layer(image, vis_params, 'Landsat')
m
```

![image](https://github.com/gee-community/geemap/assets/5016453/ff21cb28-516b-48ae-8999-436da0780b6f)
