### PR TITLE
Fix ee_to_df missing column bug

### DIFF
--- a/geemap/common.py
+++ b/geemap/common.py
@@ -8940,6 +8940,9 @@ def ee_to_df(ee_object, col_names=None, sort_columns=False, **kwargs):
         if col_names is None:
             col_names = property_names
             col_names.remove("system:index")
+            for col in col_names:  # add missing columns
+                if col not in df.columns.tolist():
+                    df[col] = None
         elif not isinstance(col_names, list):
             raise TypeError("col_names must be a list")
 

--- a/geemap/geemap.py
+++ b/geemap/geemap.py
@@ -127,6 +127,9 @@ class Map(core.Map):
         self._USER_AGENT_PREFIX = "geemap"
         self.kwargs = kwargs
         super().__init__(**kwargs)
+        
+        if kwargs.get("height"):
+            self.layout.height = kwargs.get("height")
 
         # sandbox path for Voila app to restrict access to system directories.
         if "sandbox_path" not in kwargs:


### PR DESCRIPTION
This PR fixes #1775. 

When converting an `ee.Feature` to` ee.Dictionary`, GEE automatically removes the column with None values, resulting in missing columns. This PR adds the missing columns back to the dataframe. 

This PR also fixes a bug in setting map height for linked maps. 