### PR TITLE
Add GitHub Actions for Python 3.12

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ["3.8", "3.9", "3.10", "3.11"]
+                python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         steps:
             - uses: actions/checkout@v3
             - name: Set up Python


### PR DESCRIPTION
Python 3.12 was released two weeks ago. This PR adds Python 3.12 to GitHub Actions

https://github.com/actions/python-versions/releases