### PR TITLE
Improve Colorbar for supporting numpy dtypes

### DIFF
--- a/geemap/map_widgets.py
+++ b/geemap/map_widgets.py
@@ -142,23 +142,23 @@ class Colorbar(ipywidgets.Output):
         vmin = vis_params.get("min", kwargs.pop("vmin", 0))
         try:
             vmin = float(vmin) 
-        except ValueError as err:
+        except TypeError as err:
             msg = f'The provided data type of min has to be convertible to float. Instead it is {type(vmin)}.\n'
-            raise ValueError(msg + format_tb(err.__traceback__)[0] + err.args[0] + "\n") from None
+            raise TypeError(msg + format_tb(err.__traceback__)[0] + err.args[0] + "\n") from None
 
         vmax = vis_params.get("max", kwargs.pop("mvax", 1))
         try:
             vmax = float(vmax) 
-        except ValueError as err:
+        except TypeError as err:
             msg = f'The provided data type of max has to be convertible to float. Instead it is {type(vmax)}.\n'
-            raise ValueError(msg + format_tb(err.__traceback__)[0] + err.args[0] + "\n") from None
+            raise TypeError(msg + format_tb(err.__traceback__)[0] + err.args[0] + "\n") from None
 
         alpha = vis_params.get("opacity", kwargs.pop("alpha", 1))
         try:
             alpha = float(alpha)
-        except ValueError as err:
+        except TypeError as err:
             msg = f'The provided data type of opacity has to be convertible to float. Instead it is {type(alpha)}.\n'
-            raise ValueError(msg + format_tb(err.__traceback__)[0] + err.args[0] + "\n") from None
+            raise TypeError(msg + format_tb(err.__traceback__)[0] + err.args[0] + "\n") from None
 
         if "palette" in vis_params.keys():
             hexcodes = common.to_hex_colors(common.check_cmap(vis_params["palette"]))

--- a/geemap/map_widgets.py
+++ b/geemap/map_widgets.py
@@ -142,23 +142,20 @@ class Colorbar(ipywidgets.Output):
         vmin = vis_params.get("min", kwargs.pop("vmin", 0))
         try:
             vmin = float(vmin) 
-        except TypeError as err:
-            msg = f'The provided data type of min has to be convertible to float. Instead it is {type(vmin)}.\n'
-            raise TypeError(msg + format_tb(err.__traceback__)[0] + err.args[0] + "\n") from None
+        except ValueError as err:
+            raise ValueError("The provided min value must be scalar type.")
 
         vmax = vis_params.get("max", kwargs.pop("mvax", 1))
         try:
             vmax = float(vmax) 
-        except TypeError as err:
-            msg = f'The provided data type of max has to be convertible to float. Instead it is {type(vmax)}.\n'
-            raise TypeError(msg + format_tb(err.__traceback__)[0] + err.args[0] + "\n") from None
+        except ValueError as err:
+            raise ValueError("The provided max value must be scalar type.")
 
         alpha = vis_params.get("opacity", kwargs.pop("alpha", 1))
         try:
             alpha = float(alpha)
-        except TypeError as err:
-            msg = f'The provided data type of opacity has to be convertible to float. Instead it is {type(alpha)}.\n'
-            raise TypeError(msg + format_tb(err.__traceback__)[0] + err.args[0] + "\n") from None
+        except ValueError as err:
+            raise ValueError("opacity or alpha value must be scalar type.")
 
         if "palette" in vis_params.keys():
             hexcodes = common.to_hex_colors(common.check_cmap(vis_params["palette"]))

--- a/geemap/map_widgets.py
+++ b/geemap/map_widgets.py
@@ -11,6 +11,8 @@ import ipywidgets
 
 from . import common
 
+from traceback import format_tb
+
 
 def _set_css_in_cell_output():
     display(
@@ -109,9 +111,9 @@ class Colorbar(ipywidgets.Output):
         Raises:
             TypeError: If the vis_params is not a dictionary.
             ValueError: If the orientation is not either horizontal or vertical.
-            ValueError: If the provided min value is not scalar type.
-            ValueError: If the provided max value is not scalar type.
-            ValueError: If the provided opacity value is not scalar type.
+            ValueError: If the provided min value is not convertible to float.
+            ValueError: If the provided max value is not convertible to float.
+            ValueError: If the provided opacity value is not convertible to float.
             ValueError: If cmap or palette is not provided.
         """
 
@@ -138,16 +140,25 @@ class Colorbar(ipywidgets.Output):
         width, height = self._get_dimensions(orientation, kwargs)
 
         vmin = vis_params.get("min", kwargs.pop("vmin", 0))
-        if type(vmin) not in (int, float):
-            raise TypeError("The provided min value must be scalar type.")
+        try:
+            vmin = float(vmin) 
+        except ValueError as err:
+            msg = f'The provided data type of min has to be convertible to float. Instead it is {type(vmin)}.\n'
+            raise ValueError(msg + format_tb(err.__traceback__)[0] + err.args[0] + "\n") from None
 
         vmax = vis_params.get("max", kwargs.pop("mvax", 1))
-        if type(vmax) not in (int, float):
-            raise TypeError("The provided max value must be scalar type.")
+        try:
+            vmax = float(vmax) 
+        except ValueError as err:
+            msg = f'The provided data type of max has to be convertible to float. Instead it is {type(vmax)}.\n'
+            raise ValueError(msg + format_tb(err.__traceback__)[0] + err.args[0] + "\n") from None
 
         alpha = vis_params.get("opacity", kwargs.pop("alpha", 1))
-        if type(alpha) not in (int, float):
-            raise TypeError("The provided opacity or alpha value must be type scalar.")
+        try:
+            alpha = float(alpha)
+        except ValueError as err:
+            msg = f'The provided data type of opacity has to be convertible to float. Instead it is {type(alpha)}.\n'
+            raise ValueError(msg + format_tb(err.__traceback__)[0] + err.args[0] + "\n") from None
 
         if "palette" in vis_params.keys():
             hexcodes = common.to_hex_colors(common.check_cmap(vis_params["palette"]))

--- a/tests/test_map_widgets.py
+++ b/tests/test_map_widgets.py
@@ -197,11 +197,11 @@ class TestColorbar(unittest.TestCase):
         self.normalize_class_mock.assert_called_with(vmin=-1.5, vmax=1)
 
     def test_colorbar_invalid_min(self):
-        with self.assertRaisesRegex(TypeError, "min value must be scalar type"):
+        with self.assertRaisesRegex(ValueError, "min value must be scalar type"):
             map_widgets.Colorbar(vis_params={"min": "invalid_min"})
 
     def test_colorbar_invalid_max(self):
-        with self.assertRaisesRegex(TypeError, "max value must be scalar type"):
+        with self.assertRaisesRegex(ValueError, "max value must be scalar type"):
             map_widgets.Colorbar(vis_params={"max": "invalid_max"})
 
     def test_colorbar_opacity(self):
@@ -218,7 +218,7 @@ class TestColorbar(unittest.TestCase):
 
     def test_colorbar_invalid_alpha(self):
         with self.assertRaisesRegex(
-            TypeError, "opacity or alpha value must be type scalar"
+            ValueError, "opacity or alpha value must be scalar type"
         ):
             map_widgets.Colorbar(alpha="invalid_alpha", colors=self.TEST_COLORS)
 


### PR DESCRIPTION
Worked with vis_params 'min' and 'max':

- Accept types other than (int, float), for example numpy.float32. In deed, anything that can be converted to float is accepted (since the type requirement comes from numpy.linspace).
- Improved error messages in case 'min', 'max' can not be converted to float.

See [this discussion](https://github.com/gee-community/geemap/issues/1771)