### PR TITLE
__init__.py: Do not wrap an exception when reraising.

### DIFF
--- a/geemap/__init__.py
+++ b/geemap/__init__.py
@@ -52,7 +52,7 @@ else:
             print(
                 "Please restart Jupyter kernel after installation if you encounter any errors when importing geemap."
             )
-        raise Exception(e)
+        raise e
 
 if _use_eerepr():
     import eerepr


### PR DESCRIPTION
Wrapping `Exception` around `e` messes with the exception `e`, so just `raise e`