### PR TITLE
Fix draw control geodesic bug

### DIFF
--- a/geemap/common.py
+++ b/geemap/common.py
@@ -2733,7 +2733,7 @@ def geojson_to_ee(geo_json, geodesic=False, encoding="utf-8"):
                     radius = geo_json["properties"]["style"]["radius"]
                     geom = geom.buffer(radius)
                 else:
-                    geom = ee.Geometry(geo_json["geometry"])
+                    geom = ee.Geometry(geo_json["geometry"], "", geodesic)
             elif (
                 geo_json["geometry"]["type"] == "Point"
             ):  # Checks whether it is a point


### PR DESCRIPTION
The `geojson_to_ee` function has a bug, resulting in drawn features always become geodesic features. This PR fixes this bug. 

Before:
![image](https://github.com/gee-community/geemap/assets/5016453/029e5a97-f322-4847-b9db-38d8d10cb21a)

After:
![image](https://github.com/gee-community/geemap/assets/5016453/d9236cf7-93dd-4b0d-9f1f-99832922a54e)
