### PR TITLE
Fix removing drawn feature bug

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -12,7 +12,7 @@ jobs:
                   fetch-depth: 0
             - uses: actions/setup-python@v4
               with:
-                  python-version: 3.9
+                  python-version: "3.11"
             - name: Install GDAL
               run: |
                   python -m pip install --upgrade pip

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
                   fetch-depth: 0
             - uses: actions/setup-python@v4
               with:
-                  python-version: 3.9
+                  python-version: "3.11"
             - name: Install GDAL
               run: |
                   python -m pip install --upgrade pip

--- a/geemap/geemap.py
+++ b/geemap/geemap.py
@@ -2479,6 +2479,8 @@ class Map(core.Map):
         """Removes user-drawn geometries from the map"""
         if self._draw_control is not None:
             self._draw_control.reset()
+        if "Drawn Features" in self.ee_layers:
+            self.ee_layers.pop("Drawn Features")
 
     def remove_last_drawn(self):
         """Removes last user-drawn geometry from the map"""

--- a/geemap/plotlymap.py
+++ b/geemap/plotlymap.py
@@ -717,7 +717,7 @@ class Map(go.FigureWidget):
             **kwargs,
         )
 
-        self.add_basemap("Stamen.Terrain")
+        self.add_basemap("Esri.WorldTopoMap")
         self.add_trace(heatmap)
 
     def add_gdf(

--- a/geemap/toolbar.py
+++ b/geemap/toolbar.py
@@ -4928,7 +4928,7 @@ def plotly_basemap_gui(canvas, map_min_width="78%", map_max_width="98%"):
 
     map_widget.layout.width = map_min_width
 
-    value = "Stamen.Terrain"
+    value = "Esri.WorldTopoMap"
     m.add_basemap(value)
 
     dropdown = widgets.Dropdown(

--- a/tests/test_basemaps.py
+++ b/tests/test_basemaps.py
@@ -51,7 +51,7 @@ class TestXyzToLeaflet(unittest.TestCase):
         expected_keys = {
             "custom_xyz": "OpenStreetMap",
             "custom_wms": "USGS NAIP Imagery",
-            "xyzservices_xyz": "Stamen.Terrain",
+            "xyzservices_xyz": "Esri.WorldTopoMap",
         }
         for _, expected_name in expected_keys.items():
             self.assertIn(expected_name, self.tiles)


### PR DESCRIPTION
Fix #1804 

Calling `m.remove_drawn_features()` should remove the `Draw Features` from `m.ee_layers`. Otherwise, it throws an error when trying to draw new features. 