### PR TITLE
Fix removing layer bug

### DIFF
--- a/geemap/core.py
+++ b/geemap/core.py
@@ -715,6 +715,9 @@ class Map(ipyleaflet.Map, MapInterface):
                 control.close()
             return
 
+        if hasattr(widget, "name") and widget.name in self.ee_layers:
+            self.ee_layers.pop(widget.name)
+
         if ee_layer := self.ee_layers.pop(widget, None):
             tile_layer = ee_layer.get("ee_layer", None)
             if tile_layer is not None:


### PR DESCRIPTION
Fix #1812 

Removing an EE layer from the map should also update the `Map.ee_layers` attribute. Otherwise, it will throw an error when trying to add a new layer with the same layer name because the widget has already been closed. 