### PR TITLE
Add Map.layer_to_image method

### DIFF
--- a/docs/notebooks/139_layer_to_image.ipynb
+++ b/docs/notebooks/139_layer_to_image.ipynb
@@ -1,0 +1,151 @@
+{
+    "cells": [
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "<a href=\"https://githubtocolab.com/gee-community/geemap/blob/master/examples/notebooks/139_layer_to_image.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open in Colab\"/></a>\n",
+                "\n",
+                "**Converting an Earth Engine layer to an image**\n",
+                "\n",
+                "This notebook demonstrates how to convert an Earth Engine layer to an image. It can very useful when you want to export an Earth Engine layer with custom visualization parameters. It should be much better than taking a screenshot of the layer. You can specify the scale of the image and the region to export."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# !pip install -U geemap geedim"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "import ee\n",
+                "import geemap"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "m = geemap.Map(center=(41.0462, -109.7424), zoom=6)\n",
+                "\n",
+                "dem = ee.Image('USGS/SRTMGL1_003')\n",
+                "landsat7 = ee.Image('LANDSAT/LE7_TOA_5YEAR/1999_2003').select(\n",
+                "    ['B1', 'B2', 'B3', 'B4', 'B5', 'B7']\n",
+                ")\n",
+                "\n",
+                "vis_params = {\n",
+                "    'min': 0,\n",
+                "    'max': 4000,\n",
+                "    'palette': ['006633', 'E5FFCC', '662A00', 'D8D8D8', 'F5F5F5'],\n",
+                "}\n",
+                "\n",
+                "m.add_layer(\n",
+                "    landsat7,\n",
+                "    {'bands': ['B4', 'B3', 'B2'], 'min': 20, 'max': 200, 'gamma': 2},\n",
+                "    'landsat',\n",
+                ")\n",
+                "m.add_layer(dem, vis_params, 'dem', True, 1)\n",
+                "m"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "m.layer_to_image('dem', output='dem.tif', crs='EPSG:3857', region=None, scale=None)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "m.layer_to_image('dem', output='dem.jpg', scale=500)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "geemap.show_image('dem.jpg')"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "![](https://i.imgur.com/Wwomndu.jpg)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "m.layer_to_image('landsat', output='landsat.tif')"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "geemap.geotiff_to_image('landsat.tif', output='landsat.jpg')"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "geemap.show_image('landsat.jpg')"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "![](https://i.imgur.com/Oju5in1.jpg)"
+            ]
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "Python 3",
+            "language": "python",
+            "name": "python3"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.11.5"
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 5
+}

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -150,3 +150,4 @@ More video tutorials for geemap and Earth Engine are available on my [YouTube ch
 136. Downloading Earth Engine images in parallel ([notebook](https://geemap.org/notebooks/136_download_parallel))
 137. Creating a rectangular grid covering a region of interest for computing zonal statistics ([notebook](https://geemap.org/notebooks/137_create_grid))
 138. Clipping Earth Engine images interactively with the Draw Control ([notebook](https://geemap.org/notebooks/138_draw_control))
+139. Converting an Earth Engine to an image ([notebook](https://geemap.org/notebooks/139_layer_to_image))

--- a/examples/README.md
+++ b/examples/README.md
@@ -155,6 +155,7 @@ More video tutorials for geemap and Earth Engine are available on my [YouTube ch
 136. Downloading Earth Engine images in parallel ([notebook](https://geemap.org/notebooks/136_download_parallel))
 137. Creating a rectangular grid covering a region of interest for computing zonal statistics ([notebook](https://geemap.org/notebooks/137_create_grid))
 138. Clipping Earth Engine images interactively with the Draw Control ([notebook](https://geemap.org/notebooks/138_draw_control))
+139. Converting an Earth Engine to an image ([notebook](https://geemap.org/notebooks/139_layer_to_image))
 
 ### 1. Introducing the geemap Python package for interactive mapping with Google Earth Engine
 

--- a/examples/notebooks/139_layer_to_image.ipynb
+++ b/examples/notebooks/139_layer_to_image.ipynb
@@ -1,0 +1,151 @@
+{
+    "cells": [
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "<a href=\"https://githubtocolab.com/gee-community/geemap/blob/master/examples/notebooks/139_layer_to_image.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open in Colab\"/></a>\n",
+                "\n",
+                "**Converting an Earth Engine layer to an image**\n",
+                "\n",
+                "This notebook demonstrates how to convert an Earth Engine layer to an image. It can very useful when you want to export an Earth Engine layer with custom visualization parameters. It should be much better than taking a screenshot of the layer. You can specify the scale of the image and the region to export."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# !pip install -U geemap geedim"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "import ee\n",
+                "import geemap"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "m = geemap.Map(center=(41.0462, -109.7424), zoom=6)\n",
+                "\n",
+                "dem = ee.Image('USGS/SRTMGL1_003')\n",
+                "landsat7 = ee.Image('LANDSAT/LE7_TOA_5YEAR/1999_2003').select(\n",
+                "    ['B1', 'B2', 'B3', 'B4', 'B5', 'B7']\n",
+                ")\n",
+                "\n",
+                "vis_params = {\n",
+                "    'min': 0,\n",
+                "    'max': 4000,\n",
+                "    'palette': ['006633', 'E5FFCC', '662A00', 'D8D8D8', 'F5F5F5'],\n",
+                "}\n",
+                "\n",
+                "m.add_layer(\n",
+                "    landsat7,\n",
+                "    {'bands': ['B4', 'B3', 'B2'], 'min': 20, 'max': 200, 'gamma': 2},\n",
+                "    'landsat',\n",
+                ")\n",
+                "m.add_layer(dem, vis_params, 'dem', True, 1)\n",
+                "m"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "m.layer_to_image('dem', output='dem.tif', crs='EPSG:3857', region=None, scale=None)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "m.layer_to_image('dem', output='dem.jpg', scale=500)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "geemap.show_image('dem.jpg')"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "![](https://i.imgur.com/Wwomndu.jpg)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "m.layer_to_image('landsat', output='landsat.tif')"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "geemap.geotiff_to_image('landsat.tif', output='landsat.jpg')"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "geemap.show_image('landsat.jpg')"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "![](https://i.imgur.com/Oju5in1.jpg)"
+            ]
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "Python 3",
+            "language": "python",
+            "name": "python3"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.11.5"
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 5
+}

--- a/geemap/common.py
+++ b/geemap/common.py
@@ -15458,3 +15458,40 @@ def widget_template(
 
     else:
         return toolbar_widget
+
+
+def geotiff_to_image(image: str, output: str) -> None:
+    """
+    Converts a GeoTIFF file to a JPEG/PNG image.
+
+    Args:
+        image (str): The path to the input GeoTIFF file.
+        output (str): The path to save the output JPEG/PNG file.
+
+    Returns:
+        None
+    """
+
+    import rasterio
+    from PIL import Image
+
+    # Open the GeoTIFF file
+    with rasterio.open(image) as dataset:
+        # Read the image data
+        data = dataset.read()
+
+        # Convert the image data to 8-bit format (assuming it's not already)
+        if dataset.dtypes[0] != 'uint8':
+            data = (data / data.max() * 255).astype('uint8')
+
+        # Convert the image data to RGB format if it's a single band image
+        if dataset.count == 1:
+            data = data.squeeze()
+            data = data.reshape((1, data.shape[0], data.shape[1]))
+            data = data.repeat(3, axis=0)
+
+        # Create a PIL Image object from the image data
+        image = Image.fromarray(data.transpose(1, 2, 0))
+
+        # Save the image as a JPEG file
+        image.save(output)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -280,6 +280,7 @@ nav:
           - notebooks/136_download_parallel.ipynb
           - notebooks/137_create_grid.ipynb
           - notebooks/138_draw_control.ipynb
+          - notebooks/139_layer_to_image.ipynb
     #   - miscellaneous:
     #         - notebooks/cartoee_colab.ipynb
     #         - notebooks/cartoee_colorbar.ipynb


### PR DESCRIPTION
This PR adds the `Map.layer_to_image()` method, making it easier to export an Earth Engine layer with custom visualization parameters as an image to a local computer. This is a much better solution than taking a screenshot of a layer because it allows specifying the resolution of the image to export. You get what you see. 

The tif format retains the crs of the layer, which can be overlaid on other data layers using dekstop GIS. 

Other supported formats include jpg, png, etc. 

The layer on the map:
![image](https://github.com/gee-community/geemap/assets/5016453/dd711a4e-9cc1-46c8-82da-dc87b0580286)

The downloaded image:
![image](https://github.com/gee-community/geemap/assets/5016453/a184b298-cc5c-4d71-99b7-96277cc57374)
