### PR TITLE
Add the build package

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -26,5 +26,6 @@ jobs:
                   TWINE_USERNAME: ${{ secrets.PYPI_USERS }}
                   TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
               run: |
+                  pip install build  
                   python -m build
                   twine upload dist/*


### PR DESCRIPTION
The PyPI auto upload failed due to the missing build package. This PR fixes it. 