### PR TITLE
Fix Colab authentication issue

### DIFF
--- a/geemap/common.py
+++ b/geemap/common.py
@@ -61,7 +61,7 @@ def ee_initialize(
 
     if auth_mode is None:
         if in_colab_shell():
-            auth_mode = "colab"
+            auth_mode = "notebook"
         else:
             auth_mode = "localhost"
 


### PR DESCRIPTION
A temporary fix for Colab authentication issue by switching `auth_mode` from `colab` to `notebook`. See comments [here](https://github.com/gee-community/geemap/issues/1870#issuecomment-1886252948). 

Before 
```python
import ee
import geemap

ee.Authenticate(auto_mode='colab')
ee.Iinitialize(project='<your-project-id>')
m = geemap.Map()
m
```

After 
```python
import geemap
m = geemap.Map()
m
```