### PR TITLE
Fix JS-PY conversion bugs

### DIFF
--- a/geemap/conversion.py
+++ b/geemap/conversion.py
@@ -488,7 +488,7 @@ def js_to_python(
                     output += line + "\n"
 
     if show_map:
-        output += "Map"
+        output += Map
 
     out_dir = os.path.dirname(out_file)
     if not os.path.exists(out_dir):
@@ -552,9 +552,9 @@ def js_snippet_to_py(
         out_lines = []
         if import_ee:
             out_lines.append("import ee\n")
-        if import_geemap:
-            out_lines.append("import geemap\n\n")
-            out_lines.append(f"{Map} = geemap.Map()\n")
+        # if import_geemap:
+        #     out_lines.append("import geemap\n\n")
+        #     out_lines.append(f"{Map} = geemap.Map()\n")
 
         with open(out_py, encoding="utf-8") as f:
             lines = f.readlines()
@@ -577,8 +577,8 @@ def js_snippet_to_py(
                 elif index == (len(lines) - 1) and lines[index].strip() != "":
                     out_lines.append(line)
 
-        os.remove(in_js)
-        os.remove(out_py)
+        # os.remove(in_js)
+        # os.remove(out_py)
 
         if add_new_cell:
             contents = "".join(out_lines).strip()

--- a/geemap/conversion.py
+++ b/geemap/conversion.py
@@ -569,6 +569,9 @@ def js_snippet_to_py(
                     elif ".style(" in line and (".style(**" not in line):
                         line = line.replace(".style(", ".style(**")
                         out_lines.append(line)
+                    elif "({" in line:
+                        line = line.replace("({", "(**{")
+                        out_lines.append(line)
                     else:
                         out_lines.append(line)
                 elif index == (len(lines) - 1) and lines[index].strip() != "":

--- a/geemap/conversion.py
+++ b/geemap/conversion.py
@@ -577,8 +577,8 @@ def js_snippet_to_py(
                 elif index == (len(lines) - 1) and lines[index].strip() != "":
                     out_lines.append(line)
 
-        # os.remove(in_js)
-        # os.remove(out_py)
+        os.remove(in_js)
+        os.remove(out_py)
 
         if add_new_cell:
             contents = "".join(out_lines).strip()


### PR DESCRIPTION
This PR fixes two bugs reported in #1887 and #1888  @spatialthoughts

JS example:

```python
snippet = """
var geometry = ee.Geometry.Point([77.60412933051538, 12.952912912328241]);
var s2 = ee.ImageCollection('COPERNICUS/S2_HARMONIZED');

var rgbVis = {'min': 0.0, 'max': 3000, 'bands': ['B4', 'B3', 'B2']};

var filtered = s2.filter(ee.Filter.lt('CLOUDY_PIXEL_PERCENTAGE', 30)) 
  .filter(ee.Filter.date('2019-01-01', '2020-01-01')) 
  .filter(ee.Filter.bounds(geometry));

var medianComposite = filtered.median();

Map.centerObject(geometry, 10);
Map.addLayer(medianComposite, rgbVis, 'Median Composite');
"""
lines = geemap.js_snippet_to_py(
    snippet, add_new_cell=False,
    import_ee=True, import_geemap=True, show_map=True)
for line in lines:
    print(line.rstrip())
```

Output:
```python
import ee
import geemap

m = geemap.Map()

geometry = ee.Geometry.Point([77.60412933051538, 12.952912912328241])
s2 = ee.ImageCollection('COPERNICUS/S2_HARMONIZED')

rgbVis = {'min': 0.0, 'max': 3000, 'bands': ['B4', 'B3', 'B2']}

filtered = s2.filter(ee.Filter.lt('CLOUDY_PIXEL_PERCENTAGE', 30)) \
  .filter(ee.Filter.date('2019-01-01', '2020-01-01')) \
  .filter(ee.Filter.bounds(geometry))

medianComposite = filtered.median()

m.centerObject(geometry, 10)
m.addLayer(medianComposite, rgbVis, 'Median Composite')
m
```
