### PR TITLE
Update conda download links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -153,11 +153,11 @@ To use **geemap**, you must first `sign up <https://earthengine.google.com/signu
   pip install geemap
 
 
-**Geemap** is also available on `conda-forge <https://anaconda.org/conda-forge/geemap>`__. If you have `Anaconda <https://www.anaconda.com/distribution/#download-section>`__ or `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`__ installed on your computer, you can create a conda Python environment to install geemap:
+**Geemap** is also available on `conda-forge <https://anaconda.org/conda-forge/geemap>`__. If you have `Anaconda <https://www.anaconda.com/download>`__ or `Miniconda <https://docs.anaconda.com/free/miniconda>`__ installed on your computer, you can create a conda Python environment to install geemap:
 
 .. code:: python
 
-  conda create -n gee python=3.10
+  conda create -n gee python=3.11
   conda activate gee
   conda install -n base mamba -c conda-forge
   mamba install geemap -c conda-forge

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,7 +19,7 @@ pip install geemap
 ## Install from conda-forge
 
 **Geemap** is also available on [conda-forge](https://anaconda.org/conda-forge/geemap). If you have
-[Anaconda](https://www.anaconda.com/distribution/#download-section) or [Miniconda](https://docs.conda.io/en/latest/miniconda.html) installed on your computer, you can install geemap using the following command:
+[Anaconda](https://www.anaconda.com/download) or [Miniconda](https://docs.anaconda.com/free/miniconda) installed on your computer, you can install geemap using the following command:
 
 ```bash
 conda install geemap -c conda-forge
@@ -28,7 +28,7 @@ conda install geemap -c conda-forge
 The geemap package has some optional dependencies, such as [GeoPandas](https://geopandas.org) and [localtileserver](https://github.com/banesullivan/localtileserver). These optional dependencies can be challenging to install on some computers, especially Windows. It is highly recommended that you create a fresh conda environment to install geemap. Follow the commands below to set up a conda env and install geemap:
 
 ```bash
-conda create -n gee python=3.10
+conda create -n gee python=3.11
 conda activate gee
 conda install -n base mamba -c conda-forge
 mamba install geemap -c conda-forge

--- a/docs/workshops/AGU_2023.ipynb
+++ b/docs/workshops/AGU_2023.ipynb
@@ -68,7 +68,7 @@
    "id": "2",
    "metadata": {},
    "source": [
-    "Note that some geemap features do not work properly with Google Colab. If you are familiar with [Anaconda](https://www.anaconda.com/distribution/#download-section) or [Miniconda](https://docs.conda.io/en/latest/miniconda.html), it is recommended to create a new conda environment to install geemap and its optional dependencies on your local computer. \n",
+    "Note that some geemap features do not work properly with Google Colab. If you are familiar with [Anaconda](https://www.anaconda.com/download) or [Miniconda](https://docs.anaconda.com/free/miniconda), it is recommended to create a new conda environment to install geemap and its optional dependencies on your local computer. \n",
     "\n",
     "```bash\n",
     "conda create -n gee python=3.11\n",

--- a/docs/workshops/G4G_2023.ipynb
+++ b/docs/workshops/G4G_2023.ipynb
@@ -68,7 +68,7 @@
    "id": "2",
    "metadata": {},
    "source": [
-    "Note that some geemap features do not work properly with Google Colab. If you are familiar with [Anaconda](https://www.anaconda.com/distribution/#download-section) or [Miniconda](https://docs.conda.io/en/latest/miniconda.html), it is recommended to create a new conda environment to install geemap and its optional dependencies on your local computer. \n",
+    "Note that some geemap features do not work properly with Google Colab. If you are familiar with [Anaconda](https://www.anaconda.com/download) or [Miniconda](https://docs.anaconda.com/free/miniconda), it is recommended to create a new conda environment to install geemap and its optional dependencies on your local computer. \n",
     "\n",
     "```bash\n",
     "conda create -n gee python=3.11\n",

--- a/docs/workshops/GEE_Workshop_2021.ipynb
+++ b/docs/workshops/GEE_Workshop_2021.ipynb
@@ -64,7 +64,7 @@
     "\n",
     "### Prerequisite\n",
     "- A Google Earth Engine account. Sigh up [here](https://earthengine.google.com) if needed. \n",
-    "- [Miniconda](https://docs.conda.io/en/latest/miniconda.html) or [Anaconda](https://www.anaconda.com/products/individual)\n",
+    "- [Miniconda](https://docs.anaconda.com/free/miniconda) or [Anaconda](https://www.anaconda.com/products/individual)\n",
     "\n",
     "\n",
     "### Set up a conda environment\n",

--- a/docs/workshops/GeoPython_2021.ipynb
+++ b/docs/workshops/GeoPython_2021.ipynb
@@ -45,7 +45,7 @@
     "\n",
     "### Prerequisite\n",
     "- A Google Earth Engine account. Sign up [here](https://earthengine.google.com) if needed. \n",
-    "- [Miniconda](https://docs.conda.io/en/latest/miniconda.html) or [Anaconda](https://www.anaconda.com/products/individual)\n",
+    "- [Miniconda](https://docs.anaconda.com/free/miniconda) or [Anaconda](https://www.anaconda.com/products/individual)\n",
     "\n",
     "\n",
     "### Set up a conda environment\n",

--- a/docs/workshops/NCSU_2023.ipynb
+++ b/docs/workshops/NCSU_2023.ipynb
@@ -68,7 +68,7 @@
    "id": "2",
    "metadata": {},
    "source": [
-    "Note that some geemap features do not work properly with Google Colab. If you are familiar with [Anaconda](https://www.anaconda.com/distribution/#download-section) or [Miniconda](https://docs.conda.io/en/latest/miniconda.html), it is recommended to create a new conda environment to install geemap and its optional dependencies on your local computer. \n",
+    "Note that some geemap features do not work properly with Google Colab. If you are familiar with [Anaconda](https://www.anaconda.com/download) or [Miniconda](https://docs.anaconda.com/free/miniconda), it is recommended to create a new conda environment to install geemap and its optional dependencies on your local computer. \n",
     "\n",
     "```bash\n",
     "conda create -n gee python=3.11\n",

--- a/docs/workshops/SRM_Workshop_2022.ipynb
+++ b/docs/workshops/SRM_Workshop_2022.ipynb
@@ -49,7 +49,7 @@
     "\n",
     "### Prerequisite\n",
     "- A Google Earth Engine account. Sigh up [here](https://earthengine.google.com) if needed. \n",
-    "- [Miniconda](https://docs.conda.io/en/latest/miniconda.html) or [Anaconda](https://www.anaconda.com/products/individual) has been installed on your computer.\n",
+    "- [Miniconda](https://docs.anaconda.com/free/miniconda) or [Anaconda](https://www.anaconda.com/products/individual) has been installed on your computer.\n",
     "\n",
     "\n",
     "### Set up a conda environment\n",

--- a/examples/workshops/AGU_2023.ipynb
+++ b/examples/workshops/AGU_2023.ipynb
@@ -68,7 +68,7 @@
    "id": "2",
    "metadata": {},
    "source": [
-    "Note that some geemap features do not work properly with Google Colab. If you are familiar with [Anaconda](https://www.anaconda.com/distribution/#download-section) or [Miniconda](https://docs.conda.io/en/latest/miniconda.html), it is recommended to create a new conda environment to install geemap and its optional dependencies on your local computer. \n",
+    "Note that some geemap features do not work properly with Google Colab. If you are familiar with [Anaconda](https://www.anaconda.com/download) or [Miniconda](https://docs.anaconda.com/free/miniconda), it is recommended to create a new conda environment to install geemap and its optional dependencies on your local computer. \n",
     "\n",
     "```bash\n",
     "conda create -n gee python=3.11\n",

--- a/examples/workshops/G4G_2023.ipynb
+++ b/examples/workshops/G4G_2023.ipynb
@@ -68,7 +68,7 @@
    "id": "2",
    "metadata": {},
    "source": [
-    "Note that some geemap features do not work properly with Google Colab. If you are familiar with [Anaconda](https://www.anaconda.com/distribution/#download-section) or [Miniconda](https://docs.conda.io/en/latest/miniconda.html), it is recommended to create a new conda environment to install geemap and its optional dependencies on your local computer. \n",
+    "Note that some geemap features do not work properly with Google Colab. If you are familiar with [Anaconda](https://www.anaconda.com/download) or [Miniconda](https://docs.anaconda.com/free/miniconda), it is recommended to create a new conda environment to install geemap and its optional dependencies on your local computer. \n",
     "\n",
     "```bash\n",
     "conda create -n gee python=3.11\n",

--- a/examples/workshops/GEE_Workshop_2021.ipynb
+++ b/examples/workshops/GEE_Workshop_2021.ipynb
@@ -64,7 +64,7 @@
     "\n",
     "### Prerequisite\n",
     "- A Google Earth Engine account. Sigh up [here](https://earthengine.google.com) if needed. \n",
-    "- [Miniconda](https://docs.conda.io/en/latest/miniconda.html) or [Anaconda](https://www.anaconda.com/products/individual)\n",
+    "- [Miniconda](https://docs.anaconda.com/free/miniconda) or [Anaconda](https://www.anaconda.com/products/individual)\n",
     "\n",
     "\n",
     "### Set up a conda environment\n",

--- a/examples/workshops/GeoPython_2021.ipynb
+++ b/examples/workshops/GeoPython_2021.ipynb
@@ -45,7 +45,7 @@
     "\n",
     "### Prerequisite\n",
     "- A Google Earth Engine account. Sign up [here](https://earthengine.google.com) if needed. \n",
-    "- [Miniconda](https://docs.conda.io/en/latest/miniconda.html) or [Anaconda](https://www.anaconda.com/products/individual)\n",
+    "- [Miniconda](https://docs.anaconda.com/free/miniconda) or [Anaconda](https://www.anaconda.com/products/individual)\n",
     "\n",
     "\n",
     "### Set up a conda environment\n",

--- a/examples/workshops/NCSU_2023.ipynb
+++ b/examples/workshops/NCSU_2023.ipynb
@@ -68,7 +68,7 @@
    "id": "2",
    "metadata": {},
    "source": [
-    "Note that some geemap features do not work properly with Google Colab. If you are familiar with [Anaconda](https://www.anaconda.com/distribution/#download-section) or [Miniconda](https://docs.conda.io/en/latest/miniconda.html), it is recommended to create a new conda environment to install geemap and its optional dependencies on your local computer. \n",
+    "Note that some geemap features do not work properly with Google Colab. If you are familiar with [Anaconda](https://www.anaconda.com/download) or [Miniconda](https://docs.anaconda.com/free/miniconda), it is recommended to create a new conda environment to install geemap and its optional dependencies on your local computer. \n",
     "\n",
     "```bash\n",
     "conda create -n gee python=3.11\n",

--- a/examples/workshops/SRM_Workshop_2022.ipynb
+++ b/examples/workshops/SRM_Workshop_2022.ipynb
@@ -49,7 +49,7 @@
     "\n",
     "### Prerequisite\n",
     "- A Google Earth Engine account. Sigh up [here](https://earthengine.google.com) if needed. \n",
-    "- [Miniconda](https://docs.conda.io/en/latest/miniconda.html) or [Anaconda](https://www.anaconda.com/products/individual) has been installed on your computer.\n",
+    "- [Miniconda](https://docs.anaconda.com/free/miniconda) or [Anaconda](https://www.anaconda.com/products/individual) has been installed on your computer.\n",
     "\n",
     "\n",
     "### Set up a conda environment\n",


### PR DESCRIPTION
The PR updates the Anaconda/Miniconda download links. The previous download links are broken due to the recent Anaconda website updates. 