### PR TITLE
Fix image collection vis bug

### DIFF
--- a/geemap/core.py
+++ b/geemap/core.py
@@ -751,6 +751,9 @@ class Map(ipyleaflet.Map, MapInterface):
             vis_params = {}
         if name is None:
             name = f"Layer {len(self.ee_layers) + 1}"
+
+        if isinstance(ee_object, ee.ImageCollection):
+            ee_object = ee_object.mosaic()
         tile_layer = ee_tile_layers.EELeafletTileLayer(
             ee_object, vis_params, name, shown, opacity
         )


### PR DESCRIPTION
This PR fixes the bug reported in #1952 @jdbcode. 

When adding an image collection to the map,  it should be converted to an image using `collection.mosaic()`, which then is compatible with the layer editor. 

```python
import ee
import geemap

m = geemap.Map()
col = ee.ImageCollection([ee.Image(1).byte(), ee.Image(10).byte()])
m.add_layer(col)
m
```
![image](https://github.com/gee-community/geemap/assets/5016453/ea782d1c-b1d2-4956-ba95-b5e3607cf689)

