### PR TITLE
Fix netcdf_to_ee bug

### DIFF
--- a/geemap/common.py
+++ b/geemap/common.py
@@ -3217,7 +3217,7 @@ def get_image_collection_thumbnails(
         print(e)
 
 
-def netcdf_to_ee(nc_file, var_names, band_names=None, lon="lon", lat="lat"):
+def netcdf_to_ee(nc_file, var_names, band_names=None, lon="lon", lat="lat", decimal=2):
     """
     Creates an ee.Image from netCDF variables band_names that are read from nc_file. Currently only supports variables in a regular longitude/latitude grid (EPSG:4326).
 
@@ -3227,6 +3227,7 @@ def netcdf_to_ee(nc_file, var_names, band_names=None, lon="lon", lat="lat"):
         band_names (list, optional): if given, the bands are renamed to band_names. Defaults to the original var_names
         lon (str, optional): the name of the longitude variable in the netCDF file. Defaults to "lon"
         lat (str, optional): the name of the latitude variable in the netCDF file. Defaults to "lat"
+        decimal (int, optional): the number of decimal places to round the longitude and latitude values to. Defaults to 2.
 
     Returns:
         image: An ee.Image
@@ -3241,6 +3242,12 @@ def netcdf_to_ee(nc_file, var_names, band_names=None, lon="lon", lat="lat"):
         )
 
     import numpy as np
+    from collections import Counter
+
+    def most_common_value(lst):
+        counter = Counter(lst)
+        most_common = counter.most_common(1)
+        return float(format(most_common[0][0], f".{decimal}f"))
 
     try:
         if not isinstance(nc_file, str):
@@ -3261,10 +3268,12 @@ def netcdf_to_ee(nc_file, var_names, band_names=None, lon="lon", lat="lat"):
 
         dim_lon = np.unique(np.ediff1d(lon_data))
         dim_lat = np.unique(np.ediff1d(lat_data))
+        dim_lon = [most_common_value(dim_lon)]
+        dim_lat = [most_common_value(dim_lat)]
 
-        if (len(dim_lon) != 1) or (len(dim_lat) != 1):
-            print("The netCDF file is not a regular longitude/latitude grid")
-            return
+        # if (len(dim_lon) != 1) or (len(dim_lat) != 1):
+        #     print("The netCDF file is not a regular longitude/latitude grid")
+        #     return
 
         try:
             data = data.to_array()


### PR DESCRIPTION
This PR fixes the `netcdf_to_ee` bug reported in #1945 

```python
Map = geemap.Map()
image = geemap.netcdf_to_ee(nc_file="test_wu.nc", var_names="temperature", decimal=3)
Map.addLayer(image, {"min": -20, "max": 25, "palette": "coolwarm", "opacity": 0.6}, "temperature")
Map.set_center(0, 0, 10)
Map
```

![image](https://github.com/gee-community/geemap/assets/5016453/bad5289b-8339-416f-a445-876fc02e3a73)
