### PR TITLE
[core] Fix get_bounds behavior in core

### DIFF
--- a/geemap/core.py
+++ b/geemap/core.py
@@ -502,11 +502,11 @@ class Map(ipyleaflet.Map, MapInterface):
     def get_center(self) -> Sequence:
         return self.center
 
-    def get_bounds(self, as_geo_json: bool = False) -> Sequence:
+    def get_bounds(self, as_geojson: bool = False) -> Sequence:
         """Returns the bounds of the current map view.
 
         Args:
-            as_geo_json (bool, optional): If true, returns map bounds as
+            as_geojson (bool, optional): If true, returns map bounds as
                 GeoJSON. Defaults to False.
 
         Returns:
@@ -522,7 +522,7 @@ class Map(ipyleaflet.Map, MapInterface):
         # https://ipyleaflet.readthedocs.io/en/latest/map_and_basemaps/map.html#ipyleaflet.Map.fit_bounds
         coords = [bounds[0][1], bounds[0][0], bounds[1][1], bounds[1][0]]
 
-        if as_geo_json:
+        if as_geojson:
             return ee.Geometry.BBox(*coords).getInfo()
         return coords
 

--- a/geemap/core.py
+++ b/geemap/core.py
@@ -501,8 +501,9 @@ class Map(ipyleaflet.Map, MapInterface):
         """
         bounds = self.bounds
         if not bounds:
-            raise RuntimeError("Map bounds are undefined. Please display the "
-                               "map then try again.")
+            raise RuntimeError(
+                "Map bounds are undefined. Please display the " "map then try again."
+            )
         # ipyleaflet returns bounds in the format [[south, west], [north, east]]
         # https://ipyleaflet.readthedocs.io/en/latest/map_and_basemaps/map.html#ipyleaflet.Map.fit_bounds
         coords = [bounds[0][1], bounds[0][0], bounds[1][1], bounds[1][0]]

--- a/geemap/core.py
+++ b/geemap/core.py
@@ -488,9 +488,28 @@ class Map(ipyleaflet.Map, MapInterface):
     def get_center(self) -> Sequence:
         return self.center
 
-    def get_bounds(self) -> Sequence:
+    def get_bounds(self, as_geo_json: bool = False) -> Sequence:
+        """Returns the bounds of the current map view.
+
+        Args:
+            as_geo_json (bool, optional): If true, returns map bounds as
+                GeoJSON. Defaults to False.
+
+        Returns:
+            list|dict: A list in the format [west, south, east, north] in
+                degrees or a GeoJSON dictionary.
+        """
         bounds = self.bounds
-        return [bounds[0][0], bounds[0][1], bounds[1][0], bounds[1][1]]
+        if not bounds:
+            raise RuntimeError("Map bounds are undefined. Please display the "
+                               "map then try again.")
+        # ipyleaflet returns bounds in the format [[south, west], [north, east]]
+        # https://ipyleaflet.readthedocs.io/en/latest/map_and_basemaps/map.html#ipyleaflet.Map.fit_bounds
+        coords = [bounds[0][1], bounds[0][0], bounds[1][1], bounds[1][0]]
+
+        if as_geo_json:
+            return ee.Geometry.BBox(*coords).getInfo()
+        return coords
 
     def get_scale(self) -> float:
         # Reference:
@@ -871,3 +890,4 @@ class Map(ipyleaflet.Map, MapInterface):
     addLayer = add_layer
     centerObject = center_object
     setCenter = set_center
+    getBounds = get_bounds

--- a/geemap/geemap.py
+++ b/geemap/geemap.py
@@ -1159,17 +1159,7 @@ class Map(core.Map):
         Returns:
             list | dict: A list in the format [west, south, east, north] in degrees.
         """
-        bounds = self.bounds
-        coords = [bounds[0][1], bounds[0][0], bounds[1][1], bounds[1][0]]
-
-        if asGeoJSON:
-            return ee.Geometry.BBox(
-                bounds[0][1], bounds[0][0], bounds[1][1], bounds[1][0]
-            ).getInfo()
-        else:
-            return coords
-
-    getBounds = get_bounds
+        return super().get_bounds(as_geo_json=asGeoJSON)
 
     def add_cog_layer(
         self,

--- a/tests/fake_ee.py
+++ b/tests/fake_ee.py
@@ -96,6 +96,12 @@ class Geometry:
                 "type": "Point",
                 "coordinates": [120, -70],
             }
+        if self.type().value == "BBox":
+            return {
+                "geodesic": False,
+                "type": "Polygon",
+                "coordinates": [[0, 1], [1, 2], [0, 1]],
+            }
         raise ValueError("Unexpected geometry type in test: ", self.type().value)
 
     def __eq__(self, other: object):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -100,8 +100,7 @@ class TestMap(unittest.TestCase):
             "type": "Polygon",
             "coordinates": [[0, 1], [1, 2], [0, 1]],
         }
-        self.assertEqual(self.core_map.get_bounds(
-            as_geo_json=True), expected_geo_json)
+        self.assertEqual(self.core_map.get_bounds(as_geo_json=True), expected_geo_json)
 
         mock_bounds.__get__ = Mock(return_value=())
         with self.assertRaisesRegex(RuntimeError, "Map bounds are undefined"):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -89,6 +89,24 @@ class TestMap(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "Zoom must be an integer"):
             self.core_map.center_object(ee.Geometry.Point(), "2")
 
+    @unittest.mock.patch.object(core.Map, "bounds")
+    def test_get_bounds(self, mock_bounds):
+        """Tests that `get_bounds` returns the bounds of the map."""
+        mock_bounds.__get__ = Mock(return_value=[[1, 2], [3, 4]])
+        self.assertEqual(self.core_map.get_bounds(), [2, 1, 4, 3])
+        self.assertEqual(self.core_map.getBounds(), [2, 1, 4, 3])
+        expected_geo_json = {
+            "geodesic": False,
+            "type": "Polygon",
+            "coordinates": [[0, 1], [1, 2], [0, 1]],
+        }
+        self.assertEqual(self.core_map.get_bounds(
+            as_geo_json=True), expected_geo_json)
+
+        mock_bounds.__get__ = Mock(return_value=())
+        with self.assertRaisesRegex(RuntimeError, "Map bounds are undefined"):
+            self.core_map.get_bounds(as_geo_json=True)
+
     def test_add_basic_widget_by_name(self):
         """Tests that `add` adds widgets by name."""
         self._clear_default_widgets()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -100,11 +100,11 @@ class TestMap(unittest.TestCase):
             "type": "Polygon",
             "coordinates": [[0, 1], [1, 2], [0, 1]],
         }
-        self.assertEqual(self.core_map.get_bounds(as_geo_json=True), expected_geo_json)
+        self.assertEqual(self.core_map.get_bounds(as_geojson=True), expected_geo_json)
 
         mock_bounds.__get__ = Mock(return_value=())
         with self.assertRaisesRegex(RuntimeError, "Map bounds are undefined"):
-            self.core_map.get_bounds(as_geo_json=True)
+            self.core_map.get_bounds(as_geojson=True)
 
     def test_add_basic_widget_by_name(self):
         """Tests that `add` adds widgets by name."""


### PR DESCRIPTION
Also:
- added alias for getBounds,
- fixed an issue where geemap crashed without a helpful message if the map hadn't been added to the screen, and
- added some unit tests.

The behavior was correct in geemap non-core.