### PR TITLE
Remove parameters to ee.Authenticate() to get the default Colab authentication experience

### DIFF
--- a/geemap/common.py
+++ b/geemap/common.py
@@ -73,6 +73,7 @@ def ee_initialize(
     if auth_mode is None:
         if in_colab_shell():
             from google.colab import userdata
+
             if project is None:
                 try:
                     project = userdata.get("EE_PROJECT_ID")

--- a/geemap/common.py
+++ b/geemap/common.py
@@ -73,8 +73,6 @@ def ee_initialize(
     if auth_mode is None:
         if in_colab_shell():
             from google.colab import userdata
-
-            auth_args["auth_mode"] = "colab"
             if project is None:
                 try:
                     project = userdata.get("EE_PROJECT_ID")
@@ -83,7 +81,9 @@ def ee_initialize(
                     raise Exception(
                         "Please set a secret named 'EE_PROJECT_ID' in Colab or provide a project ID."
                     )
-            ee.Authenticate(**auth_args)
+            # Authentication will automatically detect the Colab environment,
+            # no additional params needed.
+            ee.Authenticate()
             ee.Initialize(**kwargs)
             return
         else:


### PR DESCRIPTION
Uses the default `ee.Authenticate()` implementation to detect the Colab environment, which will trigger the authentication dialog and set the tokens in the right place.

Tested:
https://colab.research.google.com/drive/1zf3Hvnu1CRR_tIPEaG-dlN7meiFTDngA?usp=sharing
(note: will need to set the `GOOGLE_MAPS_API_KEY` and `EE_PROJECT_ID` secrets)

![image](https://github.com/gee-community/geemap/assets/12646706/eceecdcb-3962-4a2c-b182-cd10634139a1)
![image](https://github.com/gee-community/geemap/assets/12646706/f95a90e3-ae3c-4ab8-93e3-f7d5d26ae1d8)
