### PR TITLE
Remove drawn features layer when geometries are cleared

### DIFF
--- a/geemap/core.py
+++ b/geemap/core.py
@@ -231,7 +231,11 @@ class AbstractDrawControl(object):
         if index >= 0:
             del self.geometries[index]
             del self.properties[index]
-            self._redraw_layer()
+            if self.count:
+                self._redraw_layer()
+            elif _DRAWN_FEATURES_LAYER in self.host_map.ee_layers:
+                # Remove drawn features layer if there are no geometries.
+                self.host_map.remove_layer(_DRAWN_FEATURES_LAYER)
             self._geometry_delete_dispatcher(self, geometry=geometry)
 
 
@@ -266,10 +270,6 @@ class MapDrawControl(ipyleaflet.DrawControl, AbstractDrawControl):
                     self._handle_geometry_edited(geo_json)
                 elif action == "deleted":
                     self._handle_geometry_deleted(geo_json)
-                    # Remove drawn features layer if there are no geometries.
-                    if not self.count:
-                        if _DRAWN_FEATURES_LAYER in self.host_map.ee_layers:
-                            self.host_map.remove_layer(_DRAWN_FEATURES_LAYER)
             except Exception as e:
                 self.reset(clear_draw_control=False)
                 print("There was an error creating Earth Engine Feature.")

--- a/geemap/core.py
+++ b/geemap/core.py
@@ -15,7 +15,7 @@ from . import ee_tile_layers
 from . import map_widgets
 from . import toolbar
 
-DRAWN_FEATURES_LAYER = "Drawn Features"
+_DRAWN_FEATURES_LAYER = "Drawn Features"
 
 
 class DrawActions(enum.Enum):
@@ -197,9 +197,9 @@ class AbstractDrawControl(object):
     def _redraw_layer(self):
         if self.host_map:
             self.host_map.add_layer(
-                self.collection, {"color": "blue"}, DRAWN_FEATURES_LAYER, False, 0.5
+                self.collection, {"color": "blue"}, _DRAWN_FEATURES_LAYER, False, 0.5
             )
-            self.layer = self.host_map.ee_layers.get(DRAWN_FEATURES_LAYER, {}).get(
+            self.layer = self.host_map.ee_layers.get(_DRAWN_FEATURES_LAYER, {}).get(
                 "ee_layer", None
             )
 
@@ -268,8 +268,8 @@ class MapDrawControl(ipyleaflet.DrawControl, AbstractDrawControl):
                     self._handle_geometry_deleted(geo_json)
                     # Remove drawn features layer if there are no geometries.
                     if not self.count:
-                        if DRAWN_FEATURES_LAYER in self.host_map.ee_layers:
-                            self.host_map.remove_layer(DRAWN_FEATURES_LAYER)
+                        if _DRAWN_FEATURES_LAYER in self.host_map.ee_layers:
+                            self.host_map.remove_layer(_DRAWN_FEATURES_LAYER)
             except Exception as e:
                 self.reset(clear_draw_control=False)
                 print("There was an error creating Earth Engine Feature.")

--- a/geemap/core.py
+++ b/geemap/core.py
@@ -197,15 +197,11 @@ class AbstractDrawControl(object):
     def _redraw_layer(self):
         if self.host_map:
             self.host_map.add_layer(
-                self.collection,
-                {"color": "blue"},
-                DRAWN_FEATURES_LAYER,
-                False,
-                0.5
+                self.collection, {"color": "blue"}, DRAWN_FEATURES_LAYER, False, 0.5
             )
-            self.layer = self.host_map.ee_layers.get(
-                DRAWN_FEATURES_LAYER, {}
-            ).get("ee_layer", None)
+            self.layer = self.host_map.ee_layers.get(DRAWN_FEATURES_LAYER, {}).get(
+                "ee_layer", None
+            )
 
     def _handle_geometry_created(self, geo_json):
         geometry = common.geojson_to_ee(geo_json, geodesic=False)

--- a/tests/fake_map.py
+++ b/tests/fake_map.py
@@ -84,7 +84,10 @@ class FakeMap:
         pass
 
     def remove_layer(self, layer):
+        if isinstance(layer, str):
+            layer = self.ee_layers[layer]["ee_layer"]
         self.layers.remove(layer)
+        del self.ee_layers[layer.name]
 
     def get_layer_names(self):
         return [layer.name for layer in self.layers]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -202,8 +202,8 @@ class TestAbstractDrawControl(unittest.TestCase):
     }
 
     def setUp(self):
-        map = fake_map.FakeMap()
-        self._draw_control = TestAbstractDrawControl.TestDrawControl(map)
+        self.map = fake_map.FakeMap()
+        self._draw_control = TestAbstractDrawControl.TestDrawControl(self.map)
 
     def tearDown(self):
         pass
@@ -220,6 +220,7 @@ class TestAbstractDrawControl(unittest.TestCase):
         self.assertEquals(self._draw_control.collection, fake_ee.FeatureCollection([]))
         self.assertIsNone(self._draw_control.last_feature)
         self.assertEquals(self._draw_control.count, 0)
+        self.assertFalse("Drawn Features" in self.map.ee_layers)
 
     def test_handles_creation(self):
         self._draw_control.create(self.geo_json)
@@ -227,12 +228,15 @@ class TestAbstractDrawControl(unittest.TestCase):
             self._draw_control.geometries,
             [fake_ee.Geometry(self.geo_json["geometry"])],
         )
+        self.assertTrue("Drawn Features" in self.map.ee_layers)
 
     def test_handles_deletion(self):
         self._draw_control.create(self.geo_json)
+        self.assertTrue("Drawn Features" in self.map.ee_layers)
         self.assertEquals(len(self._draw_control.geometries), 1)
         self._draw_control.delete(0)
         self.assertEquals(len(self._draw_control.geometries), 0)
+        self.assertFalse("Drawn Features" in self.map.ee_layers)
 
     def test_handles_edit(self):
         self._draw_control.create(self.geo_json)
@@ -292,6 +296,7 @@ class TestAbstractDrawControl(unittest.TestCase):
         self._draw_control.reset(clear_draw_control=True)
         self.assertEquals(len(self._draw_control.geometries), 0)
         self.assertEquals(len(self._draw_control.geo_jsons), 0)
+        self.assertFalse("Drawn Features" in self.map.ee_layers)
 
         self._draw_control.create(self.geo_json)
         self.assertEquals(len(self._draw_control.geometries), 1)
@@ -300,6 +305,7 @@ class TestAbstractDrawControl(unittest.TestCase):
         self._draw_control.reset(clear_draw_control=False)
         self.assertEquals(len(self._draw_control.geometries), 0)
         self.assertEquals(len(self._draw_control.geo_jsons), 1)
+        self.assertFalse("Drawn Features" in self.map.ee_layers)
 
     def test_remove_geometry(self):
         self._draw_control.create(self.geo_json)


### PR DESCRIPTION
- Ensures that whenever the last drawn geometry is removed, regardless of whether it was deleted from the map using the draw control tools or reset using the `draw_control.reset()` method, the "Drawn Features" layer will also be removed from the layers list.

See: https://colab.research.google.com/drive/1vzHVOhtEr9lQwKqPHh3CkF2FIVcQ5SLN?usp=sharing

<img width="688" alt="Screenshot 2024-06-11 at 6 51 38 PM" src="https://github.com/gee-community/geemap/assets/12646706/38997bc4-ec74-4e43-8004-464de2aa96fd">
<img width="710" alt="Screenshot 2024-06-11 at 6 51 50 PM" src="https://github.com/gee-community/geemap/assets/12646706/b3ee2817-201e-4716-8247-591f9a037581">
<img width="690" alt="Screenshot 2024-06-11 at 6 51 59 PM" src="https://github.com/gee-community/geemap/assets/12646706/6b1dc33b-c936-4486-99d9-e0c5c38f1fa2">

