### PR TITLE
Default the layer manager to be opened on map initialization and other toolbar tweaks

### DIFF
--- a/geemap/core.py
+++ b/geemap/core.py
@@ -641,6 +641,8 @@ class Map(ipyleaflet.Map, MapInterface):
             widget=toolbar_val, position=position
         )
         super().add(toolbar_control)
+        # Enable the layer manager by default.
+        toolbar_val.toggle_layers(True)
 
     def _add_inspector(self, position: str, **kwargs) -> None:
         if self._inspector:

--- a/geemap/toolbar.py
+++ b/geemap/toolbar.py
@@ -153,9 +153,7 @@ class Toolbar(widgets.VBox):
 
         self.toolbar_header = widgets.HBox(
             layout=widgets.Layout(
-                display="flex",
-                justify_content="flex-end",
-                align_items="center"
+                display="flex", justify_content="flex-end", align_items="center"
             )
         )
         self.toolbar_header.children = [self.layers_button, self.toolbar_button]

--- a/geemap/toolbar.py
+++ b/geemap/toolbar.py
@@ -164,10 +164,6 @@ class Toolbar(widgets.VBox):
         self.layers_button.observe(self._layers_btn_click, "value")
 
         super().__init__(children=[self.toolbar_header])
-        toolbar_event = ipyevents.Event(
-            source=self, watched_events=["mouseenter", "mouseleave"]
-        )
-        toolbar_event.on_dom_event(self._handle_toolbar_event)
 
     def reset(self):
         """Resets the toolbar so that no widget is selected."""
@@ -204,13 +200,6 @@ class Toolbar(widgets.VBox):
             self.toggle_widget.tooltip = self._TOGGLE_TOOL_EXPAND_TOOLTIP
             self.toggle_widget.icon = self._TOGGLE_TOOL_EXPAND_ICON
 
-    def _handle_toolbar_event(self, event):
-        if event["type"] == "mouseenter":
-            self.children = [self.toolbar_header, self.toolbar_footer]
-        elif event["type"] == "mouseleave":
-            if not self.toolbar_button.value and not self.layers_button.value:
-                self.children = [self.toolbar_header]
-
     def _toolbar_btn_click(self, change):
         if change["new"]:
             self.layers_button.value = False
@@ -220,14 +209,15 @@ class Toolbar(widgets.VBox):
                 self.children = [self.toolbar_header]
 
     def _layers_btn_click(self, change):
+        # Allow callbacks to set accessory_widget to prevent flicker on click.
+        if self.on_layers_toggled:
+            self.on_layers_toggled(change["new"])
         if change["new"]:
             self.toolbar_button.value = False
             self.children = [self.toolbar_header, self.toolbar_footer]
         else:
             if not self.toolbar_button.value:
                 self.children = [self.toolbar_header]
-        if self.on_layers_toggled:
-            self.on_layers_toggled(change["new"])
 
     @property
     def accessory_widget(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -138,8 +138,10 @@ class TestMap(unittest.TestCase):
             toolbar_control, ipywidgets.ToggleButton, lambda c: c.tooltip == "Layers"
         )
         self.assertTrue(layer_button.value)
-        self.assertIsNotNone(utils.query_widget(toolbar_control, map_widgets.LayerManager))
-        
+        self.assertIsNotNone(
+            utils.query_widget(toolbar_control, map_widgets.LayerManager)
+        )
+
         toolbar_button = utils.query_widget(
             toolbar_control, ipywidgets.ToggleButton, lambda c: c.tooltip == "Toolbar"
         )
@@ -155,12 +157,20 @@ class TestMap(unittest.TestCase):
 
         # Closing the toolbar button shows both buttons in the header.
         toolbar_button.value = False
-        self.assertIsNotNone(utils.query_widget(
-            toolbar_control, ipywidgets.ToggleButton, lambda c: c.tooltip == "Toolbar"
-        ))
-        self.assertIsNotNone(utils.query_widget(
-            toolbar_control, ipywidgets.ToggleButton, lambda c: c.tooltip == "Layers"
-        ))
+        self.assertIsNotNone(
+            utils.query_widget(
+                toolbar_control,
+                ipywidgets.ToggleButton,
+                lambda c: c.tooltip == "Toolbar",
+            )
+        )
+        self.assertIsNotNone(
+            utils.query_widget(
+                toolbar_control,
+                ipywidgets.ToggleButton,
+                lambda c: c.tooltip == "Layers",
+            )
+        )
 
     def test_add_draw_control(self):
         """Tests adding and getting the draw widget."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8,7 +8,7 @@ import ee
 import ipyleaflet
 import ipywidgets
 
-from geemap import core, toolbar
+from geemap import core, map_widgets, toolbar
 from tests import fake_ee, fake_map, utils
 
 
@@ -133,15 +133,34 @@ class TestMap(unittest.TestCase):
 
         self.assertEqual(len(self.core_map.controls), 1)
         toolbar_control = self.core_map.controls[0].widget
-        utils.query_widget(
+        # Layer manager is selected and open by default.
+        layer_button = utils.query_widget(
+            toolbar_control, ipywidgets.ToggleButton, lambda c: c.tooltip == "Layers"
+        )
+        self.assertTrue(layer_button.value)
+        self.assertIsNotNone(utils.query_widget(toolbar_control, map_widgets.LayerManager))
+        
+        toolbar_button = utils.query_widget(
             toolbar_control, ipywidgets.ToggleButton, lambda c: c.tooltip == "Toolbar"
-        ).value = True  # Open the grid of tools.
+        )
+        toolbar_button.value = True  # Open the grid of tools.
+        self.assertFalse(layer_button.value)
+
         tool_grid = utils.query_widget(toolbar_control, ipywidgets.GridBox).children
 
         self.assertEqual(len(tool_grid), 3)
         self.assertEqual(tool_grid[0].tooltip, "Basemap selector")
         self.assertEqual(tool_grid[1].tooltip, "Inspector")
         self.assertEqual(tool_grid[2].tooltip, "Get help")
+
+        # Closing the toolbar button shows both buttons in the header.
+        toolbar_button.value = False
+        self.assertIsNotNone(utils.query_widget(
+            toolbar_control, ipywidgets.ToggleButton, lambda c: c.tooltip == "Toolbar"
+        ))
+        self.assertIsNotNone(utils.query_widget(
+            toolbar_control, ipywidgets.ToggleButton, lambda c: c.tooltip == "Layers"
+        ))
 
     def test_add_draw_control(self):
         """Tests adding and getting the draw widget."""


### PR DESCRIPTION
- The toolbar will now always show both the layer and toolbar buttons.
- On core map initialization, the layer manager will be opened by default.
- Right justified the buttons so that they didn't shift places when the layer manager is opened.
- The hover to open toolbar feature was kept in order to not disrupt existing workflows, however I noticed that this feature only works in Jupyter Lab and not Colab.

See: https://colab.research.google.com/drive/1HHQomXhy-vS68qiMu6AOhDmrsLq6OZwe#scrollTo=IouG0AzwPFID

<img width="704" alt="Screenshot 2024-06-11 at 8 49 42 PM" src="https://github.com/gee-community/geemap/assets/12646706/942b87f8-712a-4f51-b8f6-eb69f1b79b75">
<img width="702" alt="Screenshot 2024-06-11 at 8 49 56 PM" src="https://github.com/gee-community/geemap/assets/12646706/77c8b4bd-8e2e-4c30-a87c-d39862948852">
<img width="697" alt="Screenshot 2024-06-11 at 8 50 21 PM" src="https://github.com/gee-community/geemap/assets/12646706/b747f575-d0ab-4877-acc7-8764585d68be">
