### PR TITLE
[core] Add colorbar/legend support

### DIFF
--- a/geemap/core.py
+++ b/geemap/core.py
@@ -810,6 +810,7 @@ class Map(ipyleaflet.Map, MapInterface):
     def _add_legend(
         self,
         title: str = "Legend",
+        legend_dict: Dict[str, str] = None,
         keys: List[Any] = None,
         colors: List[Any] = None,
         position: str = "bottomright",
@@ -823,6 +824,9 @@ class Map(ipyleaflet.Map, MapInterface):
 
         Args:
             title (str, optional): Title of the legend. Defaults to 'Legend'.
+            legend_dict (dict, optional): A dictionary containing legend items
+                as keys and color as values. If provided, keys and colors will
+                be ignored. Defaults to None.
             keys (list, optional): A list of legend keys. Defaults to None.
             colors (list, optional): A list of legend colors. Defaults to None.
             position (str, optional): Position of the legend. Defaults to
@@ -838,6 +842,7 @@ class Map(ipyleaflet.Map, MapInterface):
         """
         legend = map_widgets.Legend(
             title,
+            legend_dict,
             keys,
             colors,
             position,

--- a/geemap/core.py
+++ b/geemap/core.py
@@ -545,7 +545,7 @@ class Map(ipyleaflet.Map, MapInterface):
 
     def _find_widget_of_type(
         self, widget_type: Type, return_control: bool = False
-    ) -> Optional[Any]:
+    ) -> Optional[ipywidgets.Widget]:
         """Finds a widget in the controls with the passed in type."""
         for widget in self.controls:
             if isinstance(widget, ipyleaflet.WidgetControl):
@@ -774,6 +774,113 @@ class Map(ipyleaflet.Map, MapInterface):
             "vis_params": vis_params,
         }
         super().add(tile_layer)
+
+    def _add_legend(
+        self,
+        title: str = "Legend",
+        keys: List[Any] = None,
+        colors: List[Any] = None,
+        position: str = "bottomright",
+        builtin_legend: str = None,
+        layer_name: str = None,
+        add_header: bool = True,
+        widget_args: Dict[Any, Any] = None,
+        **kwargs,
+    ):
+        """Adds a customized legend to the map.
+
+        Args:
+            title (str, optional): Title of the legend. Defaults to 'Legend'.
+            keys (list, optional): A list of legend keys. Defaults to None.
+            colors (list, optional): A list of legend colors. Defaults to None.
+            position (str, optional): Position of the legend. Defaults to
+                'bottomright'.
+            builtin_legend (str, optional): Name of the builtin legend to add
+                to the map. Defaults to None.
+            layer_name (str, optional): The associated layer for the legend.
+                Defaults to None.
+            add_header (bool, optional): Whether the legend can be closed or
+                not. Defaults to True.
+            widget_args (dict, optional): Additional arguments passed to the
+                widget_template() function. Defaults to {}.
+        """
+        legend = map_widgets.Legend(
+            title,
+            keys,
+            colors,
+            position,
+            builtin_legend,
+            add_header,
+            widget_args,
+            **kwargs,
+        )
+        control = ipyleaflet.WidgetControl(widget=legend, position=position)
+        if layer := self.ee_layers.get(layer_name, None):
+            if old_legend := layer.pop("legend", None):
+                self.remove(old_legend)
+            layer["legend"] = control
+
+        super().add(control)
+        return control
+
+    def _add_colorbar(
+        self,
+        vis_params=None,
+        cmap="gray",
+        discrete=False,
+        label=None,
+        orientation="horizontal",
+        position="bottomright",
+        transparent_bg=False,
+        layer_name=None,
+        font_size=9,
+        axis_off=False,
+        max_width=None,
+        **kwargs,
+    ):
+        """Add a matplotlib colorbar to the map.
+
+        Args:
+            vis_params (dict): Visualization parameters as a dictionary. See https://developers.google.com/earth-engine/guides/image_visualization for options.
+            cmap (str, optional): Matplotlib colormap. Defaults to "gray". See https://matplotlib.org/3.3.4/tutorials/colors/colormaps.html#sphx-glr-tutorials-colors-colormaps-py for options.
+            discrete (bool, optional): Whether to create a discrete colorbar. Defaults to False.
+            label (str, optional): Label for the colorbar. Defaults to None.
+            orientation (str, optional): Orientation of the colorbar, such as "vertical" and "horizontal". Defaults to "horizontal".
+            position (str, optional): Position of the colorbar on the map. It can be one of: topleft, topright, bottomleft, and bottomright. Defaults to "bottomright".
+            transparent_bg (bool, optional): Whether to use transparent background. Defaults to False.
+            layer_name (str, optional): The layer name associated with the colorbar. Defaults to None.
+            font_size (int, optional): Font size for the colorbar. Defaults to 9.
+            axis_off (bool, optional): Whether to turn off the axis. Defaults to False.
+            max_width (str, optional): Maximum width of the colorbar in pixels. Defaults to None.
+
+        Raises:
+            TypeError: If the vis_params is not a dictionary.
+            ValueError: If the orientation is not either horizontal or vertical.
+            TypeError: If the provided min value is not scalar type.
+            TypeError: If the provided max value is not scalar type.
+            TypeError: If the provided opacity value is not scalar type.
+            TypeError: If cmap or palette is not provided.
+        """
+        colorbar = map_widgets.Colorbar(
+            vis_params,
+            cmap,
+            discrete,
+            label,
+            orientation,
+            transparent_bg,
+            font_size,
+            axis_off,
+            max_width,
+            **kwargs,
+        )
+        control = ipyleaflet.WidgetControl(widget=colorbar, position=position)
+        if layer := self.ee_layers.get(layer_name, None):
+            if old_colorbar := layer.pop("colorbar", None):
+                self.remove(old_colorbar)
+            layer["colorbar"] = control
+
+        super().add(control)
+        return control
 
     def _open_help_page(
         self, host_map: MapInterface, selected: bool, item: toolbar.Toolbar.Item

--- a/geemap/geemap.py
+++ b/geemap/geemap.py
@@ -753,8 +753,9 @@ class Map(core.Map):
         try:
             legend = self._add_legend(
                 title,
-                keys or legend_dict.keys(),
-                colors or legend_dict.values(),
+                legend_dict,
+                keys,
+                colors,
                 position,
                 builtin_legend,
                 layer_name,

--- a/geemap/map_widgets.py
+++ b/geemap/map_widgets.py
@@ -229,6 +229,7 @@ class Legend(ipywidgets.VBox):
     def __init__(
         self,
         title="Legend",
+        legend_dict=None,
         keys=None,
         colors=None,
         position="bottomright",
@@ -241,6 +242,9 @@ class Legend(ipywidgets.VBox):
 
          Args:
             title (str, optional): Title of the legend. Defaults to 'Legend'.
+            legend_dict (dict, optional): A dictionary containing legend items
+                as keys and color as values. If provided, keys and colors will
+                be ignored. Defaults to None.
             keys (list, optional): A list of legend keys. Defaults to None.
             colors (list, optional): A list of legend colors. Defaults to None.
             position (str, optional): Position of the legend. Defaults to
@@ -278,6 +282,15 @@ class Legend(ipywidgets.VBox):
         if not os.path.exists(legend_template):
             raise ValueError("The legend template does not exist.")
 
+        if legend_dict is not None:
+            if not isinstance(legend_dict, dict):
+                raise TypeError("The legend dict must be a dictionary.")
+            else:
+                keys = list(legend_dict.keys())
+                colors = list(legend_dict.values())
+                if all(isinstance(item, tuple) for item in colors):
+                    colors = Legend.__convert_rgb_colors_to_hex(colors)
+
         if "labels" in kwargs:
             keys = kwargs["labels"]
             kwargs.pop("labels")
@@ -314,9 +327,10 @@ class Legend(ipywidgets.VBox):
                 legend_dict = builtin_legends[builtin_legend]
                 keys = list(legend_dict.keys())
                 colors = list(legend_dict.values())
+            if all(isinstance(item, tuple) for item in colors):
+                colors = Legend.__convert_rgb_colors_to_hex(colors)
 
         Legend.__check_if_allowed(position, "position", Legend.ALLOWED_POSITIONS)
-
         header = []
         footer = []
         content = Legend.__create_legend_items(keys, colors)

--- a/geemap/map_widgets.py
+++ b/geemap/map_widgets.py
@@ -1508,7 +1508,7 @@ class _RasterLayerEditor(ipywidgets.VBox):
             if selected != "Any":
                 n_class = int(self._classes_dropdown.value)
 
-            colors = pyplot.cm.get_cmap(self._colormap_dropdown.value, n_class)
+            colors = pyplot.get_cmap(self._colormap_dropdown.value, n_class)
             cmap_colors = [
                 matplotlib.colors.rgb2hex(colors(i))[1:] for i in range(colors.N)
             ]
@@ -1569,7 +1569,7 @@ class _RasterLayerEditor(ipywidgets.VBox):
             if self._classes_dropdown.value != "Any":
                 n_class = int(self._classes_dropdown.value)
 
-            colors = pyplot.cm.get_cmap(self._colormap_dropdown.value, n_class)
+            colors = pyplot.get_cmap(self._colormap_dropdown.value, n_class)
             cmap_colors = [
                 matplotlib.colors.rgb2hex(colors(i))[1:] for i in range(colors.N)
             ]
@@ -2125,7 +2125,7 @@ class _VectorLayerEditor(ipywidgets.VBox):
                 if selected != "Any":
                     n_class = int(self._classes_dropdown.value)
 
-                colors = pyplot.cm.get_cmap(self._colormap_dropdown.value, n_class)
+                colors = pyplot.get_cmap(self._colormap_dropdown.value, n_class)
                 cmap_colors = [
                     matplotlib.colors.rgb2hex(colors(i))[1:] for i in range(colors.N)
                 ]
@@ -2150,7 +2150,7 @@ class _VectorLayerEditor(ipywidgets.VBox):
             if self._classes_dropdown.value != "Any":
                 n_class = int(self._classes_dropdown.value)
 
-            colors = pyplot.cm.get_cmap(self._colormap_dropdown.value, n_class)
+            colors = pyplot.get_cmap(self._colormap_dropdown.value, n_class)
             cmap_colors = [
                 matplotlib.colors.rgb2hex(colors(i))[1:] for i in range(colors.N)
             ]

--- a/tests/fake_map.py
+++ b/tests/fake_map.py
@@ -81,7 +81,6 @@ class FakeMap:
 
     def add(self, obj):
         del obj  # Unused.
-        pass
 
     def remove_layer(self, layer):
         if isinstance(layer, str):
@@ -99,10 +98,65 @@ class FakeMap:
         i = self.find_layer_index(old_layer)
         if i >= 0:
             self.layers[i] = new_layer
-        pass
 
     def add_basemap(self, basemap="HYBRID", show=True, **kwargs):
         self.add_layer(FakeTileLayer(name=basemap, visible=show))
+
+    def _add_legend(
+        self,
+        title=None,
+        keys=None,
+        colors=None,
+        position=None,
+        builtin_legend=None,
+        layer_name=None,
+        add_header=None,
+        widget_args=None,
+        **kwargs,
+    ):
+        del (
+            title,
+            keys,
+            colors,
+            position,
+            builtin_legend,
+            add_header,
+            widget_args,
+            kwargs,
+        )
+        if layer := self.ee_layers.get(layer_name):
+            layer["legend"] = {}
+
+    def _add_colorbar(
+        self,
+        vis_params=None,
+        cmap=None,
+        discrete=None,
+        label=None,
+        orientation=None,
+        position=None,
+        transparent_bg=None,
+        layer_name=None,
+        font_size=None,
+        axis_off=None,
+        max_width=None,
+        **kwargs,
+    ):
+        del (
+            vis_params,
+            cmap,
+            discrete,
+            label,
+            orientation,
+            position,
+            transparent_bg,
+            font_size,
+            axis_off,
+            max_width,
+            kwargs,
+        )
+        if layer := self.ee_layers.get(layer_name):
+            layer["colorbar"] = {}
 
     @property
     def cursor_style(self):

--- a/tests/test_map_widgets.py
+++ b/tests/test_map_widgets.py
@@ -276,10 +276,6 @@ class TestLegend(unittest.TestCase):
         ):
             map_widgets.Legend(colors=["invalid_tuple"])
 
-    def test_legend_dict_not_a_dictionary(self):
-        with self.assertRaisesRegex(TypeError, "The legend dict must be a dictionary."):
-            map_widgets.Legend(legend_dict="invalid_legend_dict")
-
 
 @patch.object(ee, "Algorithms", fake_ee.Algorithms)
 @patch.object(ee, "FeatureCollection", fake_ee.FeatureCollection)


### PR DESCRIPTION
**Changes:**
- Added private `_add_legend` and `_add_colorbar` APIs in core.
  - I'm not comfortable exposing a new public API in core until it has been thoroughly reviewed.
- Fixed legend support in geemap non-core.
  - Colors weren't being passed to the constructor properly.
- Simplified the legend/colorbar creation logic (string tokenization).

**Design decisions:**
- **Reversible decision:** We don't keep track of "unowned" legends or colorbars in core.
  - Unowned here meaning it's not attached to any particular layer.
  - Using public core APIs, it's not possible to create an unowned map.

**Testing:**
- Tested programmatic and manual legend and colorbar creation on both core and non-core.