### PR TITLE
Fix draw control editing bug

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,10 +19,10 @@ jobs:
                   python-version: "3.11"
             - name: Install GDAL
               run: conda install -c conda-forge gdal --yes
-            - name: Test GDAL installation
-              run: |
-                  python -c "from osgeo import gdal"
-                  gdalinfo --version
+            # - name: Test GDAL installation
+            #   run: |
+            #       python -c "from osgeo import gdal"
+            #       gdalinfo --version
             - name: Install dependencies
               run: |
                   python -m pip install --upgrade pip

--- a/geemap/core.py
+++ b/geemap/core.py
@@ -213,7 +213,7 @@ class AbstractDrawControl(object):
                     old_layer.visible,
                     0.5,
                 )
-                self.host_map.substitute_layer(old_layer, new_layer)
+                self.host_map.substitute(old_layer, new_layer)
                 self.layer = self.host_map.ee_layers.get(_DRAWN_FEATURES_LAYER, {}).get(
                     "ee_layer", None
                 )

--- a/geemap/core.py
+++ b/geemap/core.py
@@ -181,23 +181,6 @@ class AbstractDrawControl(object):
         self.geometries = [
             common.geojson_to_ee(geo_json, geodesic=False) for geo_json in test_geojsons
         ]
-        # i = 0
-        # while i < self.count and i < len(test_geojsons):
-        #     self.geometries = []
-
-        #     local_geometry = None
-        #     test_geometry = None
-        #     while i < self.count and i < len(test_geojsons):
-        #         local_geometry = self.geometries[i]
-        #         test_geometry = common.geojson_to_ee(test_geojsons[i], geodesic=False)
-        #         if test_geometry == local_geometry:
-        #             i += 1
-        #         else:
-        #             break
-        #     if i < self.count and test_geometry is not None:
-        #         self.geometries[i] = test_geometry
-        # if self.layer is not None:
-        #     self._redraw_layer()
 
     def _redraw_layer(self):
         if self.host_map:
@@ -279,13 +262,6 @@ class MapDrawControl(ipyleaflet.DrawControl, AbstractDrawControl):
         """
         super(MapDrawControl, self).__init__(host_map=host_map, **kwargs)
 
-    # NOTE: Overridden for backwards compatibility, where edited geometries are
-    # added to the layer instead of modified in place. Remove when
-    # https://github.com/jupyter-widgets/ipyleaflet/issues/1119 is fixed to
-    # allow geometry edits to be reflected on the tile layer.
-    # def _handle_geometry_edited(self, geo_json):
-    #     return self._handle_geometry_created(geo_json)
-
     def _get_synced_geojson_from_draw_control(self):
         return [data.copy() for data in self.data]
 
@@ -306,20 +282,15 @@ class MapDrawControl(ipyleaflet.DrawControl, AbstractDrawControl):
 
         self.on_draw(handle_draw)
 
-        # NOTE: Uncomment the following code once
-        # https://github.com/jupyter-widgets/ipyleaflet/issues/1119 is fixed
-        # to allow edited geometries to be reflected instead of added.
         def handle_data_update(_):
             self._sync_geometries()
+            # Need to refresh the layer if the last action was an edit.
             if self.last_draw_action == DrawActions.EDITED:
                 self._redraw_layer()
 
         self.observe(handle_data_update, "data")
 
     def _remove_geometry_at_index_on_draw_control(self, index):
-        # NOTE: Uncomment the following code once
-        # https://github.com/jupyter-widgets/ipyleaflet/issues/1119 is fixed to
-        # remove drawn geometries with `remove_last_drawn()`.
         del self.data[index]
         self.send_state(key="data")
 

--- a/geemap/core.py
+++ b/geemap/core.py
@@ -183,37 +183,38 @@ class AbstractDrawControl(object):
         ]
 
     def _redraw_layer(self):
-        if self.host_map:
-            # If the layer already exists, substitute it. This can avoid flickering.
-            if _DRAWN_FEATURES_LAYER in self.host_map.ee_layers:
-                old_layer = self.host_map.ee_layers.get(_DRAWN_FEATURES_LAYER, {})[
-                    "ee_layer"
-                ]
-                new_layer = ee_tile_layers.EELeafletTileLayer(
-                    self.collection,
-                    {"color": "blue"},
-                    _DRAWN_FEATURES_LAYER,
-                    old_layer.visible,
-                    0.5,
-                )
-                self.host_map.substitute(old_layer, new_layer)
-                self.layer = self.host_map.ee_layers.get(_DRAWN_FEATURES_LAYER, {}).get(
-                    "ee_layer", None
-                )
-                self.host_map.ee_layers.get(_DRAWN_FEATURES_LAYER, {})[
-                    "ee_layer"
-                ] = new_layer
-            else:  # Otherwise, add the layer.
-                self.host_map.add_layer(
-                    self.collection,
-                    {"color": "blue"},
-                    _DRAWN_FEATURES_LAYER,
-                    False,
-                    0.5,
-                )
-                self.layer = self.host_map.ee_layers.get(_DRAWN_FEATURES_LAYER, {}).get(
-                    "ee_layer", None
-                )
+        if not self.host_map:
+            return
+        # If the layer already exists, substitute it. This can avoid flickering.
+        if _DRAWN_FEATURES_LAYER in self.host_map.ee_layers:
+            old_layer = self.host_map.ee_layers.get(_DRAWN_FEATURES_LAYER, {})[
+                "ee_layer"
+            ]
+            new_layer = ee_tile_layers.EELeafletTileLayer(
+                self.collection,
+                {"color": "blue"},
+                _DRAWN_FEATURES_LAYER,
+                old_layer.visible,
+                0.5,
+            )
+            self.host_map.substitute(old_layer, new_layer)
+            self.layer = self.host_map.ee_layers.get(_DRAWN_FEATURES_LAYER, {}).get(
+                "ee_layer", None
+            )
+            self.host_map.ee_layers.get(_DRAWN_FEATURES_LAYER, {})[
+                "ee_layer"
+            ] = new_layer
+        else:  # Otherwise, add the layer.
+            self.host_map.add_layer(
+                self.collection,
+                {"color": "blue"},
+                _DRAWN_FEATURES_LAYER,
+                False,
+                0.5,
+            )
+            self.layer = self.host_map.ee_layers.get(_DRAWN_FEATURES_LAYER, {}).get(
+                "ee_layer", None
+            )
 
     def _handle_geometry_created(self, geo_json):
         geometry = common.geojson_to_ee(geo_json, geodesic=False)
@@ -229,7 +230,6 @@ class AbstractDrawControl(object):
         self.last_geometry = geometry
         self.last_draw_action = DrawActions.EDITED
         self._sync_geometries()
-        # self._redraw_layer()
         self._geometry_edit_dispatcher(self, geometry=geometry)
 
     def _handle_geometry_deleted(self, geo_json):


### PR DESCRIPTION
This PR fixes the draw control bug reproted in #1899. In addtion, I improved the `redraw_layer()` function by utilizing substitute layer rather than removing and adding layer. This avoids the layer flickering. 

Colab: https://colab.research.google.com/drive/1E9Uf4WJV060BDnH1yiwA0k5eajtLbmGj?usp=sharing

Note: The recent GDAL version fails on Windows GitHub Actions. It is irrelevant to this PR. I commented it out temporarily. 

![Peek 2024-06-15 20-42](https://github.com/gee-community/geemap/assets/5016453/672a2dd5-f1c6-4728-8c35-4fa126498daf)
