### PR TITLE
Fix folium split map bug

### DIFF
--- a/docs/workshops/SatMOC_2024.ipynb
+++ b/docs/workshops/SatMOC_2024.ipynb
@@ -1111,9 +1111,9 @@
    "outputs": [],
    "source": [
     "m = geemap.Map(center=[40, -100], zoom=4)\n",
-    "pdsi_col = ee.ImageCollection(\"USGS/NLCD_RELEASES/2019_REL/NLCD\").select(\"landcover\")\n",
+    "collection = ee.ImageCollection(\"USGS/NLCD_RELEASES/2019_REL/NLCD\").select(\"landcover\")\n",
     "vis_params = {\"bands\": [\"landcover\"]}\n",
-    "years = pdsi_col.aggregate_array(\"system:index\").getInfo()\n",
+    "years = collection.aggregate_array(\"system:index\").getInfo()\n",
     "years"
    ]
   },
@@ -1133,8 +1133,8 @@
    "outputs": [],
    "source": [
     "m.ts_inspector(\n",
-    "    left_ts=pdsi_col,\n",
-    "    right_ts=pdsi_col,\n",
+    "    left_ts=collection,\n",
+    "    right_ts=collection,\n",
     "    left_names=years,\n",
     "    right_names=years,\n",
     "    left_vis=vis_params,\n",
@@ -1232,7 +1232,7 @@
    "source": [
     "m = geemap.Map(center=[37.75, -122.45], zoom=12)\n",
     "\n",
-    "pdsi_col = (\n",
+    "collection = (\n",
     "    ee.ImageCollection(\"COPERNICUS/S2_SR\")\n",
     "    .filterBounds(ee.Geometry.Point([-122.45, 37.75]))\n",
     "    .filterMetadata(\"CLOUDY_PIXEL_PERCENTAGE\", \"less_than\", 10)\n",
@@ -1240,7 +1240,7 @@
     "\n",
     "vis_params = {\"min\": 0, \"max\": 4000, \"bands\": [\"B8\", \"B4\", \"B3\"]}\n",
     "\n",
-    "m.add_time_slider(pdsi_col, vis_params)\n",
+    "m.add_time_slider(collection, vis_params)\n",
     "m"
    ]
   },

--- a/geemap/foliumap.py
+++ b/geemap/foliumap.py
@@ -2338,7 +2338,9 @@ class Map(folium.Map):
                     f"right_layer must be one of the following: {', '.join(basemaps.keys())} or a string url to a tif file."
                 )
 
-            control = SideBySideLayers(layer_left=left_layer, layer_right=right_layer)
+            control = folium.plugins.SideBySideLayers(
+                layer_left=left_layer, layer_right=right_layer
+            )
             left_layer.add_to(self)
             right_layer.add_to(self)
             control.add_to(self)


### PR DESCRIPTION
The folium split map control is not working properly. The slider does not swipe the map. Replacing with the folium offical plugin, which apprears to have resolved the issue. 