### PR TITLE
Fix Colab authentication bug

### DIFF
--- a/geemap/common.py
+++ b/geemap/common.py
@@ -86,6 +86,7 @@ def ee_initialize(
             # no additional params needed.
             ee.Authenticate()
             ee.Initialize(**kwargs)
+            ee.data.setUserAgent(user_agent)
             return
         else:
             auth_mode = "notebook"

--- a/geemap/common.py
+++ b/geemap/common.py
@@ -67,6 +67,8 @@ def ee_initialize(
     from .__init__ import __version__
 
     user_agent = f"{user_agent_prefix}/{__version__}"
+    ee.data.setUserAgent(user_agent)
+
     if "http_transport" not in kwargs:
         kwargs["http_transport"] = httplib2.Http()
 
@@ -86,7 +88,6 @@ def ee_initialize(
             # no additional params needed.
             ee.Authenticate()
             ee.Initialize(**kwargs)
-            ee.data.setUserAgent(user_agent)
             return
         else:
             auth_mode = "notebook"
@@ -154,8 +155,6 @@ def ee_initialize(
             except Exception:
                 ee.Authenticate(**auth_args)
                 ee.Initialize(**kwargs)
-
-    ee.data.setUserAgent(user_agent)
 
 
 def ee_export_image(

--- a/geemap/common.py
+++ b/geemap/common.py
@@ -71,7 +71,7 @@ def ee_initialize(
         kwargs["http_transport"] = httplib2.Http()
 
     if auth_mode is None:
-        if in_colab_shell():
+        if in_colab_shell() and (ee.data._credentials is None):
             from google.colab import userdata
 
             if project is None:


### PR DESCRIPTION
This PR fixes the Colab authentication bug that causes duplicate authentication. If a session has already been authenticated and initialized by EE, geemap should skip the authentication.  

```python
import ee
import geemap

ee.Authenticate()
ee.Initialize(project="YOUR-PROJECT-ID")
m = geemap.Map()
```