### PR TITLE
Fix layer spinner bug

### DIFF
--- a/geemap/map_widgets.py
+++ b/geemap/map_widgets.py
@@ -848,7 +848,7 @@ class LayerManager(ipywidgets.VBox):
             if event["type"] == "mouseenter":
                 spinner.icon = "times"
             elif event["type"] == "mouseleave":
-                if layer.loading:
+                if hasattr(layer, "loading") and layer.loading:
                     spinner.icon = "spinner spin lg"
                 else:
                     spinner.icon = "times"

--- a/geemap/toolbar.py
+++ b/geemap/toolbar.py
@@ -2547,17 +2547,18 @@ def timelapse_gui(m=None, basemap="HYBRID"):
 
             with output:
                 output.clear_output()
-                link = create_download_link(
-                    out_gif,
-                    title="Click here to download: ",
-                )
-                display(link)
-                if nd_bands is not None:
-                    link_nd = create_download_link(
-                        out_gif.replace(".gif", "_nd.gif"),
+                if os.path.exists(out_gif):
+                    link = create_download_link(
+                        out_gif,
                         title="Click here to download: ",
                     )
-                    display(link_nd)
+                    display(link)
+                    if nd_bands is not None:
+                        link_nd = create_download_link(
+                            out_gif.replace(".gif", "_nd.gif"),
+                            title="Click here to download: ",
+                        )
+                        display(link_nd)
 
             m.default_style = {"cursor": "default"}
 


### PR DESCRIPTION
Some layer types such as `ImageOverlay` and `VideoOverlay` do not have the `loading` attribute. The layer spinner should only be applicable to layer types with the `loading` attribute. 

This PR also fixes the Landsat timelapse bug when the timelapse GIF is not generated. 