### PR TITLE
Update GitHub Actions to Python 3.12

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -12,7 +12,7 @@ jobs:
                   fetch-depth: 0
             - uses: actions/setup-python@v5
               with:
-                  python-version: "3.11"
+                  python-version: "3.12"
             - name: Install GDAL
               run: |
                   python -m pip install --upgrade pip
@@ -26,7 +26,7 @@ jobs:
                   python -m pip install --upgrade pip
                   pip install --user --no-cache-dir Cython
                   pip install .[all]
-                  pip install numpy==1.26.4
+                  # pip install numpy==1.26.4
             - name: LOAD EE CREDENTIALS
               run: python ./.github/ee_token.py
               env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
                   fetch-depth: 0
             - uses: actions/setup-python@v5
               with:
-                  python-version: "3.11"
+                  python-version: "3.12"
             - name: Install GDAL
               run: |
                   python -m pip install --upgrade pip
@@ -28,7 +28,7 @@ jobs:
                   python -m pip install --upgrade pip
                   pip install --user --no-cache-dir Cython
                   pip install .[all]
-                  pip install numpy==1.26.4
+                  # pip install numpy==1.26.4
             - name: LOAD EE CREDENTIALS
               run: python ./.github/ee_token.py
               env:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,7 +15,7 @@ jobs:
             fail-fast: false
             matrix:
                 config:
-                    - { os: macOS-latest, py: "3.11" }
+                    - { os: macOS-latest, py: "3.12" }
         env:
             SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
         steps:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ["3.9", "3.10", "3.11"]
+                python-version: ["3.9", "3.10", "3.11", "3.12"]
         steps:
             - uses: actions/checkout@v4
             - name: Set up Python

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,7 +16,7 @@ jobs:
               uses: conda-incubator/setup-miniconda@v3
               with:
                   auto-activate-base: true
-                  python-version: "3.11"
+                  python-version: "3.12"
             - name: Install GDAL
               run: conda install -c conda-forge gdal --yes
             # - name: Test GDAL installation


### PR DESCRIPTION
Python 3.13 will be released on October 1. This PR updates all GitHub Actions to use Python 3.12