### PR TITLE
Refactor LitElement logic out into a superclass

### DIFF
--- a/js/lit_widget.ts
+++ b/js/lit_widget.ts
@@ -1,0 +1,57 @@
+import { LitElement, PropertyValues } from "lit";
+
+import { reverseMap } from "./utils";
+
+export abstract class LitWidget<
+    ModelType,
+    SubclassType extends LitWidget<any, any>
+> extends LitElement {
+    private _model: any | undefined = undefined; // AnyModel<ModelType>
+
+    abstract modelNameToViewName(): Map<
+        keyof ModelType,
+        keyof SubclassType | null
+    >;
+
+    viewNameToModelName(): Map<keyof SubclassType | null, keyof ModelType> {
+        return reverseMap(this.modelNameToViewName());
+    }
+
+    set model(model: any) {
+        // TODO(naschmitz): model should be of type AnyModel<ModelType>. AnyModel
+        // requires a type that conforms to a non-exported member of anywidget.
+        this._model = model;
+        for (const [modelKey, widgetKey] of this.modelNameToViewName()) {
+            if (widgetKey) {
+                // Get initial values from the Python model.
+                (this as any)[widgetKey] = model.get(modelKey);
+                // Listen for updates to the model.
+                model.on(`change:${String(modelKey)}`, () => {
+                    (this as any)[widgetKey] = model.get(modelKey);
+                });
+            }
+        }
+    }
+
+    get model(): any {
+        // TODO(naschmitz): model should be of type AnyModel<ModelType>. AnyModel
+        // requires a type that conforms to a non-exported member of anywidget.
+        return this._model;
+    }
+
+    updated(changedProperties: PropertyValues<SubclassType>): void {
+        // Update the model properties so they're reflected in Python.
+        const viewToModelMap = this.viewNameToModelName();
+        for (const [viewProp, _] of changedProperties) {
+            const castViewProp = viewProp as keyof SubclassType;
+            if (viewToModelMap.has(castViewProp)) {
+                const modelProp = viewToModelMap.get(castViewProp);
+                this._model?.set(
+                    modelProp as any,
+                    this[castViewProp as keyof this] as any
+                );
+            }
+        }
+        this._model?.save_changes();
+    }
+}

--- a/js/utils.ts
+++ b/js/utils.ts
@@ -38,7 +38,9 @@ export async function updateChildren(
 export function reverseMap<K, V>(map: Map<K, V>): Map<V, K> {
     const reversedMap = new Map<V, K>();
     for (const [key, value] of map.entries()) {
-        reversedMap.set(value, key);
+        if (value != null) {
+            reversedMap.set(value, key);
+        }
     }
     return reversedMap;
 }


### PR DESCRIPTION
Move LitElement-specific logic into an abstract superclass to reduce the boilerplate code for new LitElement anywidgets. This superclass handles:

- subscribing to model changes and updating the corresponding LitElement properties, and
- propagating LitElement property updates to the model.