### PR TITLE
Separate model and view code in the computed object and inspector tree

### DIFF
--- a/tests/data/feature_tree.json
+++ b/tests/data/feature_tree.json
@@ -1,0 +1,50 @@
+{
+    "label": "Feature",
+    "children": [
+        {
+            "label": "type: Feature",
+            "children": [],
+            "expanded": false,
+            "topLevel": false
+        },
+        {
+            "label": "id: 00000000000000000001",
+            "children": [],
+            "expanded": false,
+            "topLevel": false
+        },
+        {
+            "label": "properties: Object (4 properties)",
+            "children": [
+                {
+                    "label": "fullname: some-full-name",
+                    "children": [],
+                    "expanded": false,
+                    "topLevel": false
+                },
+                {
+                    "label": "linearid: 110469267091",
+                    "children": [],
+                    "expanded": false,
+                    "topLevel": false
+                },
+                {
+                    "label": "mtfcc: S1400",
+                    "children": [],
+                    "expanded": false,
+                    "topLevel": false
+                },
+                {
+                    "label": "rttyp: some-rttyp",
+                    "children": [],
+                    "expanded": false,
+                    "topLevel": false
+                }
+            ],
+            "expanded": false,
+            "topLevel": false
+        }
+    ],
+    "expanded": false,
+    "topLevel": false
+}

--- a/tests/data/image_collection_tree.json
+++ b/tests/data/image_collection_tree.json
@@ -1,0 +1,208 @@
+{
+    "label": "ImageCollection",
+    "children": [
+        {
+            "label": "type: ImageCollection",
+            "children": [],
+            "expanded": false,
+            "topLevel": false
+        },
+        {
+            "label": "bands: List (0 elements)",
+            "children": [],
+            "expanded": false,
+            "topLevel": false
+        },
+        {
+            "label": "features",
+            "children": [
+                {
+                    "label": "0: \"some/image/id\"",
+                    "children": [
+                        {
+                            "label": "type: Image",
+                            "children": [],
+                            "expanded": false,
+                            "topLevel": false
+                        },
+                        {
+                            "label": "bands: List (1 elements)",
+                            "children": [
+                                {
+                                    "label": "0: \"band-1\", int, EPSG:4326, 4x2 px",
+                                    "children": [
+                                        {
+                                            "label": "id: band-1",
+                                            "children": [],
+                                            "expanded": false,
+                                            "topLevel": false
+                                        },
+                                        {
+                                            "label": "data_type",
+                                            "children": [
+                                                {
+                                                    "label": "type: PixelType",
+                                                    "children": [],
+                                                    "expanded": false,
+                                                    "topLevel": false
+                                                },
+                                                {
+                                                    "label": "precision: int",
+                                                    "children": [],
+                                                    "expanded": false,
+                                                    "topLevel": false
+                                                },
+                                                {
+                                                    "label": "min: -2",
+                                                    "children": [],
+                                                    "expanded": false,
+                                                    "topLevel": false
+                                                },
+                                                {
+                                                    "label": "max: 2",
+                                                    "children": [],
+                                                    "expanded": false,
+                                                    "topLevel": false
+                                                }
+                                            ],
+                                            "expanded": false,
+                                            "topLevel": false
+                                        },
+                                        {
+                                            "label": "dimensions",
+                                            "children": [
+                                                {
+                                                    "label": "0: 4",
+                                                    "children": [],
+                                                    "expanded": false,
+                                                    "topLevel": false
+                                                },
+                                                {
+                                                    "label": "1: 2",
+                                                    "children": [],
+                                                    "expanded": false,
+                                                    "topLevel": false
+                                                }
+                                            ],
+                                            "expanded": false,
+                                            "topLevel": false
+                                        },
+                                        {
+                                            "label": "crs: EPSG:4326",
+                                            "children": [],
+                                            "expanded": false,
+                                            "topLevel": false
+                                        },
+                                        {
+                                            "label": "crs_transform",
+                                            "children": [
+                                                {
+                                                    "label": "0: 1",
+                                                    "children": [],
+                                                    "expanded": false,
+                                                    "topLevel": false
+                                                },
+                                                {
+                                                    "label": "1: 0",
+                                                    "children": [],
+                                                    "expanded": false,
+                                                    "topLevel": false
+                                                },
+                                                {
+                                                    "label": "2: -180",
+                                                    "children": [],
+                                                    "expanded": false,
+                                                    "topLevel": false
+                                                },
+                                                {
+                                                    "label": "3: 0",
+                                                    "children": [],
+                                                    "expanded": false,
+                                                    "topLevel": false
+                                                },
+                                                {
+                                                    "label": "4: -1",
+                                                    "children": [],
+                                                    "expanded": false,
+                                                    "topLevel": false
+                                                },
+                                                {
+                                                    "label": "5: 84",
+                                                    "children": [],
+                                                    "expanded": false,
+                                                    "topLevel": false
+                                                }
+                                            ],
+                                            "expanded": false,
+                                            "topLevel": false
+                                        }
+                                    ],
+                                    "expanded": false,
+                                    "topLevel": false
+                                }
+                            ],
+                            "expanded": false,
+                            "topLevel": false
+                        },
+                        {
+                            "label": "version: 42",
+                            "children": [],
+                            "expanded": false,
+                            "topLevel": false
+                        },
+                        {
+                            "label": "id: some/image/id",
+                            "children": [],
+                            "expanded": false,
+                            "topLevel": false
+                        },
+                        {
+                            "label": "properties: Object (3 properties)",
+                            "children": [
+                                {
+                                    "label": "type_name: Image",
+                                    "children": [],
+                                    "expanded": false,
+                                    "topLevel": false
+                                },
+                                {
+                                    "label": "keywords",
+                                    "children": [
+                                        {
+                                            "label": "0: keyword-1",
+                                            "children": [],
+                                            "expanded": false,
+                                            "topLevel": false
+                                        },
+                                        {
+                                            "label": "1: keyword-2",
+                                            "children": [],
+                                            "expanded": false,
+                                            "topLevel": false
+                                        }
+                                    ],
+                                    "expanded": false,
+                                    "topLevel": false
+                                },
+                                {
+                                    "label": "thumb: https://some-thumbnail.png",
+                                    "children": [],
+                                    "expanded": false,
+                                    "topLevel": false
+                                }
+                            ],
+                            "expanded": false,
+                            "topLevel": false
+                        }
+                    ],
+                    "expanded": false,
+                    "topLevel": false
+                }
+            ],
+            "expanded": false,
+            "topLevel": false
+        }
+    ],
+    "expanded": false,
+    "topLevel": false
+}

--- a/tests/data/image_tree.json
+++ b/tests/data/image_tree.json
@@ -1,0 +1,182 @@
+{
+    "label": "Image (1 bands)",
+    "children": [
+        {
+            "label": "type: Image",
+            "children": [],
+            "expanded": false,
+            "topLevel": false
+        },
+        {
+            "label": "id: some/image/id",
+            "children": [],
+            "expanded": false,
+            "topLevel": false
+        },
+        {
+            "label": "version: 42",
+            "children": [],
+            "expanded": false,
+            "topLevel": false
+        },
+        {
+            "label": "bands: List (1 elements)",
+            "children": [
+                {
+                    "label": "0: \"band-1\", int, EPSG:4326, 4x2 px",
+                    "children": [
+                        {
+                            "label": "id: band-1",
+                            "children": [],
+                            "expanded": false,
+                            "topLevel": false
+                        },
+                        {
+                            "label": "data_type",
+                            "children": [
+                                {
+                                    "label": "type: PixelType",
+                                    "children": [],
+                                    "expanded": false,
+                                    "topLevel": false
+                                },
+                                {
+                                    "label": "precision: int",
+                                    "children": [],
+                                    "expanded": false,
+                                    "topLevel": false
+                                },
+                                {
+                                    "label": "min: -2",
+                                    "children": [],
+                                    "expanded": false,
+                                    "topLevel": false
+                                },
+                                {
+                                    "label": "max: 2",
+                                    "children": [],
+                                    "expanded": false,
+                                    "topLevel": false
+                                }
+                            ],
+                            "expanded": false,
+                            "topLevel": false
+                        },
+                        {
+                            "label": "dimensions",
+                            "children": [
+                                {
+                                    "label": "0: 4",
+                                    "children": [],
+                                    "expanded": false,
+                                    "topLevel": false
+                                },
+                                {
+                                    "label": "1: 2",
+                                    "children": [],
+                                    "expanded": false,
+                                    "topLevel": false
+                                }
+                            ],
+                            "expanded": false,
+                            "topLevel": false
+                        },
+                        {
+                            "label": "crs: EPSG:4326",
+                            "children": [],
+                            "expanded": false,
+                            "topLevel": false
+                        },
+                        {
+                            "label": "crs_transform",
+                            "children": [
+                                {
+                                    "label": "0: 1",
+                                    "children": [],
+                                    "expanded": false,
+                                    "topLevel": false
+                                },
+                                {
+                                    "label": "1: 0",
+                                    "children": [],
+                                    "expanded": false,
+                                    "topLevel": false
+                                },
+                                {
+                                    "label": "2: -180",
+                                    "children": [],
+                                    "expanded": false,
+                                    "topLevel": false
+                                },
+                                {
+                                    "label": "3: 0",
+                                    "children": [],
+                                    "expanded": false,
+                                    "topLevel": false
+                                },
+                                {
+                                    "label": "4: -1",
+                                    "children": [],
+                                    "expanded": false,
+                                    "topLevel": false
+                                },
+                                {
+                                    "label": "5: 84",
+                                    "children": [],
+                                    "expanded": false,
+                                    "topLevel": false
+                                }
+                            ],
+                            "expanded": false,
+                            "topLevel": false
+                        }
+                    ],
+                    "expanded": false,
+                    "topLevel": false
+                }
+            ],
+            "expanded": false,
+            "topLevel": false
+        },
+        {
+            "label": "properties: Object (3 properties)",
+            "children": [
+                {
+                    "label": "keywords",
+                    "children": [
+                        {
+                            "label": "0: keyword-1",
+                            "children": [],
+                            "expanded": false,
+                            "topLevel": false
+                        },
+                        {
+                            "label": "1: keyword-2",
+                            "children": [],
+                            "expanded": false,
+                            "topLevel": false
+                        }
+                    ],
+                    "expanded": false,
+                    "topLevel": false
+                },
+                {
+                    "label": "thumb: https://some-thumbnail.png",
+                    "children": [],
+                    "expanded": false,
+                    "topLevel": false
+                },
+                {
+                    "label": "type_name: Image",
+                    "children": [],
+                    "expanded": false,
+                    "topLevel": false
+                }
+            ],
+            "expanded": false,
+            "topLevel": false
+        }
+    ],
+    "expanded": false,
+    "topLevel": false
+}

--- a/tests/fake_ee.py
+++ b/tests/fake_ee.py
@@ -26,6 +26,32 @@ class Image:
     def reduceRegion(self, *_, **__):
         return Dictionary({"B1": 42, "B2": 3.14})
 
+    def getInfo(self):
+        return {
+            "type": "Image",
+            "bands": [
+                {
+                    "id": "band-1",
+                    "data_type": {
+                        "type": "PixelType",
+                        "precision": "int",
+                        "min": -2,
+                        "max": 2,
+                    },
+                    "dimensions": [4, 2],
+                    "crs": "EPSG:4326",
+                    "crs_transform": [1, 0, -180, 0, -1, 84],
+                },
+            ],
+            "version": 42,
+            "id": "some/image/id",
+            "properties": {
+                "type_name": "Image",
+                "keywords": ["keyword-1", "keyword-2"],
+                "thumb": "https://some-thumbnail.png",
+            },
+        }
+
 
 class List:
     def __init__(self, items, *_, **__):
@@ -164,10 +190,10 @@ class Feature:
             },
             "id": "00000000000000000001",
             "properties": {
-                "fullname": "",
+                "fullname": "some-full-name",
                 "linearid": "110469267091",
                 "mtfcc": "S1400",
-                "rttyp": "",
+                "rttyp": "some-rttyp",
             },
         }
 
@@ -178,11 +204,18 @@ class Feature:
 
 
 class ImageCollection:
-    def __init__(self, *_, **__):
-        pass
+    def __init__(self, images: list[Image], *_, **__):
+        self.images = images
 
     def mosaic(self, *_, **__):
         return Image()
+
+    def getInfo(self):
+        return {
+            "type": "ImageCollection",
+            "bands": [],
+            "features": [f.getInfo() for f in self.images],
+        }
 
 
 class Reducer:

--- a/tests/test_map_widgets.py
+++ b/tests/test_map_widgets.py
@@ -429,14 +429,14 @@ class TestInspector(unittest.TestCase):
 
         objects_root = self._query_node(self.inspector, "Objects")
         self.assertIsNotNone(objects_root)
-        layer_3_root = self._query_node(objects_root, "test-map-3: Feature ")
+        layer_3_root = self._query_node(objects_root, "test-map-3: Feature")
         self.assertIsNotNone(layer_3_root)
         self.assertIsNotNone(self._query_node(layer_3_root, "type: Feature"))
         self.assertIsNotNone(self._query_node(layer_3_root, "id: 00000000000000000001"))
-        self.assertIsNotNone(self._query_node(layer_3_root, "fullname: "))
+        self.assertIsNotNone(self._query_node(layer_3_root, "fullname: some-full-name"))
         self.assertIsNotNone(self._query_node(layer_3_root, "linearid: 110469267091"))
         self.assertIsNotNone(self._query_node(layer_3_root, "mtfcc: S1400"))
-        self.assertIsNotNone(self._query_node(layer_3_root, "rttyp: "))
+        self.assertIsNotNone(self._query_node(layer_3_root, "rttyp: some-rttyp"))
 
     def test_map_click_twice(self):
         """Tests that clicking the map a second time removes the original output."""


### PR DESCRIPTION
Before, `get_info` returned a widget representing the computed object. Now, `get_info` calls `build_computed_object_tree` to build an intermediate representation of the computed object. The intermediate representation is converted to a widget.

The advantage of this intermediate representation is:
- the majority of the tree traversal logic can be tested by comparing the resulting tree as JSON, and
- the tree can be reconstructed with different views (e.g. ipytree, custom inspector widget, etc.).