### PR TITLE
Explicitly initialize eerepr

### DIFF
--- a/geemap/__init__.py
+++ b/geemap/__init__.py
@@ -56,5 +56,7 @@ else:
 
 if _use_eerepr():
     import eerepr
+    
+    eerepr.initialize()
 
 from .report import Report

--- a/geemap/__init__.py
+++ b/geemap/__init__.py
@@ -56,7 +56,7 @@ else:
 
 if _use_eerepr():
     import eerepr
-    
+
     eerepr.initialize()
 
 from .report import Report


### PR DESCRIPTION
Hi @giswqs and team. I'm planning to update `eerepr` in the near future (aazuspan/eerepr#39) to require explicit initialization for attaching the repr methods instead of initializing on import. In other words, HTML reprs will only be available once `eerepr.initialize` is explicitly called.

This PR would allow `geemap` to continue automatically initializing `eerepr` after that release. This is backwards compatible since the initialize function was already available in past releases. The only downside will be a couple redundant `setattr` calls on import.

Happy to discuss further, especially if there are any concerns about synchronizing the release or downstream impacts on Earth Engine documentation (I don't foresee any).