### PR TITLE
Split basemap selector up into two select fields: provider and resource

### DIFF
--- a/geemap/map_widgets.py
+++ b/geemap/map_widgets.py
@@ -845,12 +845,12 @@ class BasemapSelector(anywidget.AnyWidget):
         self.provider = provider
         self.resource = resource
         self._setup_event_listeners()
-        
+
     def _parse_basemap_name(self, name: str) -> Tuple[str, str]:
         components = name.split(".")
         resource = ".".join(components[1:]) if len(components) > 1 else ""
         return components[0], resource
-        
+
     def _get_basemap_dictionary(self, basemaps: List[str]) -> Dict[str, List[str]]:
         basemaps_dict: Dict[str, List[str]] = {}
         for basemap in basemaps:

--- a/geemap/map_widgets.py
+++ b/geemap/map_widgets.py
@@ -855,10 +855,9 @@ class BasemapSelector(anywidget.AnyWidget):
         basemaps_dict: Dict[str, List[str]] = {}
         for basemap in basemaps:
             provider, resource = self._parse_basemap_name(basemap)
-            if provider not in basemaps_dict:
-                basemaps_dict[provider] = []
+            provider_map = basemaps_dict.setdefault(provider, [])
             if resource:
-                basemaps_dict[provider].append(resource)
+                provider_map.append(resource)
         return basemaps_dict
 
     def _setup_event_listeners(self) -> None:

--- a/js/basemap_selector.ts
+++ b/js/basemap_selector.ts
@@ -59,7 +59,11 @@ export class BasemapSelector extends LitWidget<
 
     render(): TemplateResult {
         return html`
-            <widget-container @close-clicked="${this.onCloseClicked}">
+            <widget-container
+                icon="map"
+                title="Basemap Selector"
+                @close-clicked="${this.onCloseClicked}"
+            >
                 <div class="vertical-flex">
                     <div class="horizontal-flex">
                         <span class="legacy-text">Provider</span>

--- a/js/container.ts
+++ b/js/container.ts
@@ -95,7 +95,7 @@ export class Container extends LitWidget<ContainerModel, Container> {
 
     private renderTitle(): HTMLTemplateResult | typeof nothing {
         if (this.title) {
-            return html`<span class="legacy-text header-text>${this.title}</span>`;
+            return html`<span class="legacy-text header-text">${this.title}</span>`;
         }
         return nothing;
     }

--- a/js/legend_customization.ts
+++ b/js/legend_customization.ts
@@ -151,7 +151,8 @@ export class LegendCustomization extends LitElement {
     }
 
     private onLabelsChanged(event: Event): void {
-        this.labels = (event.target as HTMLInputElement).value;
+        const labels = (event.target as HTMLInputElement).value;
+        this.labels = labels.split(",").map(token => token.trim());
     }
 }
 

--- a/js/lit_widget.ts
+++ b/js/lit_widget.ts
@@ -13,7 +13,7 @@ export abstract class LitWidget<
         keyof SubclassType | null
     >;
 
-    onCustomMessage?(msg: any): void {}
+    onCustomMessage?(_msg: any): void {}
 
     viewNameToModelName(): Map<keyof SubclassType | null, keyof ModelType> {
         return reverseMap(this.modelNameToViewName());

--- a/tests/basemap_selector.spec.ts
+++ b/tests/basemap_selector.spec.ts
@@ -1,6 +1,10 @@
 import { AnyModel } from "@anywidget/types";
 import "../js/basemap_selector";
-import { default as selectorRender, BasemapSelector, BasemapSelectorModel } from "../js/basemap_selector";
+import {
+    default as selectorRender,
+    BasemapSelector,
+    BasemapSelectorModel,
+} from "../js/basemap_selector";
 import { FakeAnyModel } from "./fake_anywidget";
 
 describe("<basemap-selector>", () => {
@@ -9,9 +13,11 @@ describe("<basemap-selector>", () => {
     async function makeSelector(model: AnyModel<BasemapSelectorModel>) {
         const container = document.createElement("div");
         selectorRender.render({
-            model, el: container, experimental: {
+            model,
+            el: container,
+            experimental: {
                 invoke: () => new Promise(() => [model, []]),
-            }
+            },
         });
         const element = container.firstElementChild as BasemapSelector;
         document.body.appendChild(element);
@@ -20,56 +26,71 @@ describe("<basemap-selector>", () => {
     }
 
     beforeEach(async () => {
-        selector = await makeSelector(new FakeAnyModel<BasemapSelectorModel>({
-            basemaps: ["select", "default", "bounded"],
-            value: "default",
-        }));
+        selector = await makeSelector(
+            new FakeAnyModel<BasemapSelectorModel>({
+                basemaps: {
+                    DEFAULT: [],
+                    provider: ["resource-1", "resource-2"],
+                    "another-provider": [],
+                },
+                provider: "provider",
+                resource: "resource-1",
+            })
+        );
     });
 
     afterEach(() => {
-        Array.from(document.querySelectorAll("basemap-selector")).forEach((el) => {
-            el.remove();
-        })
+        Array.from(document.querySelectorAll("basemap-selector")).forEach(
+            (el) => {
+                el.remove();
+            }
+        );
     });
 
     it("can be instantiated.", () => {
-        expect(selector.shadowRoot?.querySelector("select")?.textContent).toContain("bounded");
+        expect(
+            selector.shadowRoot?.querySelector("select")?.textContent
+        ).toContain("DEFAULT");
     });
 
-    it("renders the basemap options.", () => {
-        const options = selector.shadowRoot?.querySelectorAll("option")!;
-        expect(options.length).toBe(3);
-        expect(options[0].textContent).toContain("select");
-        expect(options[1].textContent).toContain("default");
-        expect(options[2].textContent).toContain("bounded");
-    });
+    // it("renders the basemap options.", () => {
+    //     const options = selector.shadowRoot?.querySelectorAll("option")!;
+    //     expect(options.length).toBe(3);
+    //     expect(options[0].textContent).toContain("select");
+    //     expect(options[1].textContent).toContain("default");
+    //     expect(options[2].textContent).toContain("bounded");
+    // });
 
-    it("setting the value on model changes the value on select.", async () => {
-        selector.value = "select";
-        await selector.updateComplete;
-        expect(selector.selectElement.value).toBe("select");
-    });
+    // it("setting the value on model changes the value on select.", async () => {
+    //     selector.value = "select";
+    //     await selector.updateComplete;
+    //     expect(selector.selectElement.value).toBe("select");
+    // });
 
-    it("sets value on model when option changes.", async () => {
-        const setSpy = spyOn(FakeAnyModel.prototype, "set");
-        const saveSpy = spyOn(FakeAnyModel.prototype, "save_changes");
+    // it("sets value on model when option changes.", async () => {
+    //     const setSpy = spyOn(FakeAnyModel.prototype, "set");
+    //     const saveSpy = spyOn(FakeAnyModel.prototype, "save_changes");
 
-        selector.selectElement.value = "select";
-        selector.selectElement.dispatchEvent(new Event('change'));
+    //     selector.selectElement.value = "select";
+    //     selector.selectElement.dispatchEvent(new Event("change"));
 
-        await selector.updateComplete;
-        expect(setSpy).toHaveBeenCalledOnceWith("value", "select");
-        expect(saveSpy).toHaveBeenCalledTimes(1);
-    });
+    //     await selector.updateComplete;
+    //     expect(setSpy).toHaveBeenCalledOnceWith("value", "select");
+    //     expect(saveSpy).toHaveBeenCalledTimes(1);
+    // });
 
-    it("emits close event when clicked.", async () => {
-        const sendSpy = spyOn(FakeAnyModel.prototype, "send");
-        // Close button emits an event.
-        (selector.shadowRoot?.querySelector(".close-button") as HTMLButtonElement).click();
-        await selector.updateComplete;
-        expect(sendSpy).toHaveBeenCalledOnceWith({
-            type: "click",
-            id: "close"
-        });
-    });
+    // it("emits close event when clicked.", async () => {
+    //     const sendSpy = spyOn(FakeAnyModel.prototype, "send");
+    //     // Close button emits an event.
+    //     (
+    //         selector.shadowRoot?.querySelector(
+    //             ".close-button"
+    //         ) as HTMLButtonElement
+    //     ).click();
+    //     await selector.updateComplete;
+    //     expect(sendSpy).toHaveBeenCalledOnceWith({
+    //         type: "click",
+    //         id: "close",
+    //     });
+    // });
 });

--- a/tests/basemap_selector.spec.ts
+++ b/tests/basemap_selector.spec.ts
@@ -30,11 +30,11 @@ describe("<basemap-selector>", () => {
             new FakeAnyModel<BasemapSelectorModel>({
                 basemaps: {
                     DEFAULT: [],
-                    provider: ["resource-1", "resource-2"],
+                    "a-provider": ["resource-1", "resource-2"],
                     "another-provider": [],
                 },
-                provider: "provider",
-                resource: "resource-1",
+                provider: "DEFAULT",
+                resource: "",
             })
         );
     });
@@ -53,44 +53,59 @@ describe("<basemap-selector>", () => {
         ).toContain("DEFAULT");
     });
 
-    // it("renders the basemap options.", () => {
-    //     const options = selector.shadowRoot?.querySelectorAll("option")!;
-    //     expect(options.length).toBe(3);
-    //     expect(options[0].textContent).toContain("select");
-    //     expect(options[1].textContent).toContain("default");
-    //     expect(options[2].textContent).toContain("bounded");
-    // });
+    it("selects the default provider appropriately.", () => {
+        const selects = selector.shadowRoot?.querySelectorAll("select")!;
+        const providerSelect = selects[0];
+        expect(providerSelect.value).toBe("DEFAULT");
+        expect(selects.length).toBe(1); // Resource select shouldn't be visible.
+    });
 
-    // it("setting the value on model changes the value on select.", async () => {
-    //     selector.value = "select";
-    //     await selector.updateComplete;
-    //     expect(selector.selectElement.value).toBe("select");
-    // });
+    it("setting the provider and resource on model updates the view.", async () => {
+        selector.provider = "a-provider";
+        await selector.updateComplete;
 
-    // it("sets value on model when option changes.", async () => {
-    //     const setSpy = spyOn(FakeAnyModel.prototype, "set");
-    //     const saveSpy = spyOn(FakeAnyModel.prototype, "save_changes");
+        const selects = selector.shadowRoot?.querySelectorAll("select")!;
+        expect(selects.length).toBe(2);
+        const providerSelect = selects[0];
+        const resourceSelect = selects[1];
 
-    //     selector.selectElement.value = "select";
-    //     selector.selectElement.dispatchEvent(new Event("change"));
+        expect(providerSelect.value).toBe("a-provider");
+        expect(resourceSelect.value).toBe("resource-1");
+        expect(selector.resource).toBe("resource-1");
 
-    //     await selector.updateComplete;
-    //     expect(setSpy).toHaveBeenCalledOnceWith("value", "select");
-    //     expect(saveSpy).toHaveBeenCalledTimes(1);
-    // });
+        selector.resource = "resource-2";
+        await selector.updateComplete;
 
-    // it("emits close event when clicked.", async () => {
-    //     const sendSpy = spyOn(FakeAnyModel.prototype, "send");
-    //     // Close button emits an event.
-    //     (
-    //         selector.shadowRoot?.querySelector(
-    //             ".close-button"
-    //         ) as HTMLButtonElement
-    //     ).click();
-    //     await selector.updateComplete;
-    //     expect(sendSpy).toHaveBeenCalledOnceWith({
-    //         type: "click",
-    //         id: "close",
-    //     });
-    // });
+        expect(providerSelect.value).toBe("a-provider");
+        expect(selector.provider).toBe("a-provider");
+        expect(resourceSelect.value).toBe("resource-2");
+    });
+
+    it("sets value on model when option changes.", async () => {
+        const setSpy = spyOn(FakeAnyModel.prototype, "set");
+        const saveSpy = spyOn(FakeAnyModel.prototype, "save_changes");
+
+        let selects = selector.shadowRoot?.querySelectorAll("select")!;
+        const providerSelect = selects[0];
+
+        providerSelect.value = "a-provider";
+        providerSelect.dispatchEvent(new Event("change"));
+        await selector.updateComplete;
+
+        expect(setSpy).toHaveBeenCalledWith("provider", "a-provider");
+        expect(setSpy).toHaveBeenCalledWith("resource", "resource-1");
+        expect(setSpy).toHaveBeenCalledTimes(2);
+        expect(saveSpy).toHaveBeenCalledTimes(1);
+
+        selects = selector.shadowRoot?.querySelectorAll("select")!;
+        const resourceSelect = selects[1];
+
+        resourceSelect.value = "resource-2";
+        resourceSelect.dispatchEvent(new Event("change"));
+        await selector.updateComplete;
+
+        expect(setSpy).toHaveBeenCalledWith("resource", "resource-2");
+        expect(setSpy).toHaveBeenCalledTimes(3);
+        expect(saveSpy).toHaveBeenCalledTimes(2);
+    });
 });


### PR DESCRIPTION
**Overview:**
- Split the basemap selector into two select fields: one for basemap provider, and another for the basemap resource.
- The new UX is less overwhelming/confusing, as opposed to a flat list with all the basemaps listed.
- Added Python and JS (Karma) unit tests.
- Fixed other small bugs discovered while updating the unit tests.
- **I'm open to suggestions!**

**Try it out:** https://colab.research.google.com/drive/1HMDb7UzAfxssg5uFmSWHegmMwovdVSvB?usp=sharing

**Screenshots:**
<img width="268" alt="Screenshot 2024-12-30 at 3 36 50 PM" src="https://github.com/user-attachments/assets/af80fc5e-ec24-4055-b28e-f0a93a979559" /> <img width="268" alt="Screenshot 2024-12-30 at 3 36 43 PM" src="https://github.com/user-attachments/assets/676ada19-242d-4173-95dd-fb275e65650f" />

**Video recording:** https://github.com/user-attachments/assets/18c05fb9-801e-4bad-bd71-48948f9868b4

