### PR TITLE
Add an icon and title to generic widget containers

### DIFF
--- a/js/container.ts
+++ b/js/container.ts
@@ -7,6 +7,7 @@ import { LitWidget } from "./lit_widget";
 import { materialStyles } from "./styles";
 
 export interface ContainerModel {
+    icon: string;
     title: string;
     collapsed: boolean;
     hide_close_button: boolean;
@@ -27,6 +28,14 @@ export class Container extends LitWidget<ContainerModel, Container> {
                 padding: 4px;
             }
 
+            .icon {
+                align-items: center;
+                display: flex;
+                font-size: 20px;
+                height: 28px;
+                justify-content: center;
+            }
+
             .widget-container {
                 padding: 4px;
             }
@@ -43,18 +52,20 @@ export class Container extends LitWidget<ContainerModel, Container> {
 
             .header-text {
                 align-content: center;
-                padding-left: 4px;
-                padding-right: 4px;
+                flex-grow: 1;
+                padding-right: 12px;
             }
         `,
     ];
 
+    @property({ type: String }) icon: string = "";
     @property({ type: String }) title: string = "";
     @property({ type: Boolean }) collapsed: boolean = false;
     @property({ type: Boolean }) hideCloseButton: boolean = false;
 
     modelNameToViewName(): Map<keyof ContainerModel, keyof Container | null> {
         return new Map([
+            ["icon", "icon"],
             ["collapsed", "collapsed"],
             ["title", "title"],
             ["hide_close_button", "hideCloseButton"],
@@ -64,14 +75,15 @@ export class Container extends LitWidget<ContainerModel, Container> {
     render() {
         return html`
             <div class="header">
-                ${this.renderCloseButton()}
+                <span class="icon material-symbols-outlined">${this.icon}</span>
+                ${this.renderTitle()}
                 <button
                     class="legacy-button header-button"
                     @click="${this.onCollapseToggled}"
                 >
                     ${this.renderCollapseButtonIcon()}
                 </button>
-                ${this.renderTitle()}
+                ${this.renderCloseButton()}
             </div>
             <div class="widget-container ${this.collapsed ? "hidden" : ""}">
                 <slot></slot>
@@ -93,11 +105,8 @@ export class Container extends LitWidget<ContainerModel, Container> {
         `;
     }
 
-    private renderTitle(): HTMLTemplateResult | typeof nothing {
-        if (this.title) {
-            return html`<span class="legacy-text header-text">${this.title}</span>`;
-        }
-        return nothing;
+    private renderTitle(): HTMLTemplateResult {
+        return html`<span class="legacy-text header-text">${this.title}</span>`;
     }
 
     private onCloseButtonClicked(): void {

--- a/js/inspector.ts
+++ b/js/inspector.ts
@@ -73,6 +73,8 @@ export class Inspector extends LitWidget<InspectorModel, Inspector> {
     render() {
         return html`
             <widget-container
+                icon="search"
+                title="Inspector"
                 .hideCloseButton="${this.hideCloseButton}"
                 @close-clicked="${this.onCloseButtonClicked}"
             >

--- a/js/legend.ts
+++ b/js/legend.ts
@@ -101,8 +101,8 @@ export class Legend extends LitWidget<LegendModel, Legend> {
     render() {
         return this.addHeader ? html`
             <widget-container
-                .hideCloseButton="${!this.showCloseButton}"
                 .title="${this.title}"
+                .hideCloseButton="${!this.showCloseButton}"
                 @close-clicked="${this.onCloseButtonClicked}">
                 ${this.renderLegend("")}
             </widget-container>` : this.renderLegend(this.title);


### PR DESCRIPTION
**Overview:**

- Add an icon and title to the generic widget container.
- Close and minimize buttons moved to the right-hand side of the widget container.
- Title HTML element expands to fill the gap in the header.
- Fixed other small bugs discovered while updating the unit tests.
- Other widgets that use the generic container should set `title` and `icon` on the container.

**TODOs:**

- [x] Basemap selector (once submitted and rebased).

**Screenshots:**
 
<img width="304" alt="Screenshot 2025-01-02 at 1 44 47 PM" src="https://github.com/user-attachments/assets/99f02475-0f23-477b-a390-3ff48aac6599" />
<img width="253" alt="Screenshot 2025-01-02 at 1 48 17 PM" src="https://github.com/user-attachments/assets/e29d2a1d-9c72-420c-a8ac-0cadc40b054c" />
<img width="107" alt="Screenshot 2025-01-02 at 1 38 22 PM" src="https://github.com/user-attachments/assets/4db016d2-3f52-43f0-b57a-4e5df4b5a371" />
