### PR TITLE
Separate layer manager from toolbar (and other minor UI tweaks)

### DIFF
--- a/geemap/core.py
+++ b/geemap/core.py
@@ -731,7 +731,7 @@ class Map(ipyleaflet.Map, MapInterface):
         self.top_right_layout_box = ipywidgets.GridBox(
             layout=ipywidgets.Layout(
                 grid_template_columns="auto auto",  # Two columns
-                grid_gap="0px 10px",                # 0px row gap, 10px column gap
+                grid_gap="0px 10px",  # 0px row gap, 10px column gap
             ),
         )
         self.top_right_layout_box.layout.overflow = "visible"

--- a/geemap/core.py
+++ b/geemap/core.py
@@ -1106,7 +1106,19 @@ class Map(ipyleaflet.Map, MapInterface):
             "draw_control": MapDrawControl,
             "basemap_selector": map_widgets.BasemapSelector,
         }
-        if widget_type := basic_controls.get(widget, None):
+        widget_type = basic_controls.get(widget, None)
+
+        # First, try removing the widget from any layout boxes.
+        child_to_remove = None
+        for child in self.top_right_layout_box.children:
+            if child == widget or isinstance(child, type(widget_type)):
+                child_to_remove = child
+        if child_to_remove:
+            self.top_right_layout_box.children = [
+                x for x in self.top_right_layout_box.children if x != child_to_remove
+            ]
+
+        if widget_type:
             if control := self._find_widget_of_type(widget_type, return_control=True):
                 self.remove(control)
                 control.close()

--- a/geemap/geemap.py
+++ b/geemap/geemap.py
@@ -211,6 +211,7 @@ class Map(core.Map):
 
         for control in ["toolbar_ctrl"]:
             if self.kwargs.get(control, True):
+                topright.append("layer_manager")
                 topright.append(control)
 
         for control in ["attribution_control"]:

--- a/geemap/toolbar.py
+++ b/geemap/toolbar.py
@@ -92,12 +92,6 @@ class Toolbar(anywidget.AnyWidget):
 
     _esm = pathlib.Path(__file__).parent / "static" / "toolbar.js"
 
-    # The accessory widget.
-    accessory_widgets = map_widgets.TypedTuple(
-        trait=traitlets.Instance(widgets.Widget),
-        help="The accessory widget",
-    ).tag(sync=True, **widgets.widget_serialization)
-
     # The list of main tools.
     main_tools = map_widgets.TypedTuple(
         trait=traitlets.Instance(widgets.Widget),
@@ -113,9 +107,6 @@ class Toolbar(anywidget.AnyWidget):
     # Whether the toolbar is expanded.
     expanded = traitlets.Bool(False).tag(sync=True)
 
-    # The currently selected tab.
-    tab_index = traitlets.Int(0).tag(sync=True)
-
     _TOGGLE_EXPAND_ICON = "add"
     _TOGGLE_EXPAND_TOOLTIP = "Expand toolbar"
     _TOGGLE_COLLAPSE_ICON = "remove"
@@ -126,7 +117,6 @@ class Toolbar(anywidget.AnyWidget):
         host_map: "geemap.Map",
         main_tools: List[ToolbarItem],
         extra_tools: List[ToolbarItem],
-        accessory_widgets: List[widgets.DOMWidget],
     ):
         """Adds a toolbar with `main_tools` and `extra_tools` to the `host_map`."""
         super().__init__()
@@ -145,7 +135,6 @@ class Toolbar(anywidget.AnyWidget):
             widget.callback_wrapper = lambda callback, value, tool: callback(
                 self.host_map, value, tool
             )
-        self.accessory_widgets = accessory_widgets
 
     def reset(self):
         """Resets the toolbar so that no widget is selected."""

--- a/js/basemap_selector.ts
+++ b/js/basemap_selector.ts
@@ -1,5 +1,5 @@
 import type { RenderProps } from "@anywidget/types";
-import { css, html, nothing, PropertyValues, TemplateResult } from "lit";
+import { css, html, PropertyValues, TemplateResult } from "lit";
 import { property } from "lit/decorators.js";
 
 import { legacyStyles } from "./ipywidgets_styles";
@@ -73,18 +73,14 @@ export class BasemapSelector extends LitWidget<
                             this.onProviderChanged
                         )}
                     </div>
-                    ${this.getAvailableResources().length > 0
-                        ? html`
-                              <div class="horizontal-flex">
-                                  <span class="legacy-text">Resource</span>
-                                  ${renderSelect(
-                                      this.getAvailableResources(),
-                                      this.resource,
-                                      this.onResourceChanged
-                                  )}
-                              </div>
-                          `
-                        : nothing}
+                    <div class="horizontal-flex">
+                        <span class="legacy-text">Resource</span>
+                        ${renderSelect(
+                            this.getAvailableResources(),
+                            this.resource,
+                            this.onResourceChanged
+                        )}
+                    </div>
                     <div class="horizontal-flex ">
                         <button
                             class="legacy-button"

--- a/js/container.ts
+++ b/js/container.ts
@@ -23,6 +23,12 @@ export class Container extends LitWidget<ContainerModel, Container> {
         legacyStyles,
         materialStyles,
         css`
+            .container {
+                background: var(--jp-layout-color1);
+                border-radius: 4.5px;
+                box-shadow: 4px 5px 8px 0px #9e9e9e;
+            }
+
             div {
                 background-color: var(--colab-primary-surface-color, --jp-layout-color1, white);
             }
@@ -31,6 +37,10 @@ export class Container extends LitWidget<ContainerModel, Container> {
                 display: flex;
                 gap: 4px;
                 padding: 4px;
+            }
+
+            .reversed {
+                flex-direction: row-reverse;
             }
 
             .icon {
@@ -69,6 +79,7 @@ export class Container extends LitWidget<ContainerModel, Container> {
     @property({ type: Boolean }) hideCloseButton: boolean = false;
     @property({ type: Boolean }) compactMode: boolean = false;
     @property({ type: Boolean }) noHeader: boolean = false;
+    @property({ type: Boolean }) reverseHeader: boolean = false;
 
     modelNameToViewName(): Map<keyof ContainerModel, keyof Container | null> {
         return new Map([
@@ -81,16 +92,18 @@ export class Container extends LitWidget<ContainerModel, Container> {
 
     render() {
         return html`
-            ${this.noHeader ? nothing : this.renderHeader()}
-            <div class="widget-container ${this.collapsed ? "hidden" : ""}">
-                <slot></slot>
+            <div class="container">
+                ${this.noHeader ? nothing : this.renderHeader()}
+                <div class="widget-container ${this.collapsed ? "hidden" : ""}">
+                    <slot></slot>
+                </div>
             </div>
         `;
     }
 
     private renderHeader(): TemplateResult {
         return this.compactMode ? this.renderCompactHeader() : html`
-            <div class="header">
+            <div class="header ${this.reverseHeader ? "reversed" : ""}">
                 ${this.renderIcon()}
                 ${this.title ? this.renderTitle() : nothing}
                 ${this.renderCollapseButton()}
@@ -99,7 +112,7 @@ export class Container extends LitWidget<ContainerModel, Container> {
     }
 
     private renderCompactHeader(): TemplateResult {
-        return html`<div class="header">
+        return html`<div class="header ${this.reverseHeader ? "reversed" : ""}">
             ${this.renderCollapseButton()}
             ${(this.title && !this.collapsed) ? this.renderTitle() : nothing}
             ${this.renderCloseButton()}

--- a/js/container.ts
+++ b/js/container.ts
@@ -49,6 +49,7 @@ export class Container extends LitWidget<ContainerModel, Container> {
                 font-size: 20px;
                 height: 28px;
                 justify-content: center;
+                padding: 0 4px;
             }
 
             .widget-container {
@@ -68,7 +69,7 @@ export class Container extends LitWidget<ContainerModel, Container> {
             .header-text {
                 align-content: center;
                 flex-grow: 1;
-                padding: 0 6px 0 12px;
+                padding: 0 12px 0 0;
             }
         `,
     ];

--- a/js/inspector.ts
+++ b/js/inspector.ts
@@ -73,7 +73,7 @@ export class Inspector extends LitWidget<InspectorModel, Inspector> {
     render() {
         return html`
             <widget-container
-                icon="search"
+                icon="point_scan"
                 title="Inspector"
                 .hideCloseButton="${this.hideCloseButton}"
                 @close-clicked="${this.onCloseButtonClicked}"

--- a/js/ipywidgets_styles.ts
+++ b/js/ipywidgets_styles.ts
@@ -84,6 +84,11 @@ export const legacyStyles = css`
         vertical-align: top;
     }
 
+    .legacy-select[disabled] {
+        opacity: 0.4;
+        cursor: not-allowed;
+    }
+
     .legacy-text-input {
         background: var(--jp-widgets-input-background-color);
         border: var(--jp-widgets-input-border-width) solid var(--jp-widgets-input-border-color);

--- a/js/layer_manager.ts
+++ b/js/layer_manager.ts
@@ -6,15 +6,14 @@ import { legacyStyles } from "./ipywidgets_styles";
 import { LitWidget } from "./lit_widget";
 import { loadFonts, updateChildren } from "./utils";
 
+import "./container";
+
 export interface LayerManagerModel {
     children: any;
     visible: boolean;
 }
 
-export class LayerManager extends LitWidget<
-    LayerManagerModel,
-    LayerManager
-> {
+export class LayerManager extends LitWidget<LayerManagerModel, LayerManager> {
     static get componentName() {
         return `layer-manager`;
     }
@@ -22,24 +21,28 @@ export class LayerManager extends LitWidget<
     static styles = [
         legacyStyles,
         css`
-            .container {
-                padding: 0 4px 2px 4px;
-            }
-
             .row {
                 align-items: center;
                 display: flex;
                 gap: 4px;
-                height: 30px;
+                height: 28px;
             }
 
             .visibility-checkbox {
                 margin: 2px;
             }
+
+            .layer-manager-rows {
+                display: flex;
+                flex-direction: column;
+                gap: 4px;
+            }
         `,
     ];
 
     @property() visible: boolean = false;
+    @property() tabIndex: number = 0;
+    @property() collapsed: boolean = true;
 
     modelNameToViewName(): Map<
         keyof LayerManagerModel,
@@ -53,20 +56,31 @@ export class LayerManager extends LitWidget<
 
     render(): TemplateResult {
         return html`
-            <div class="container">
-                <div class="row">
-                    <input
-                        type="checkbox"
-                        class="visibility-checkbox"
-                        .checked="${this.visible}"
-                        @change="${this.onLayerVisibilityChanged}"
-                    />
-                    <span class="legacy-text all-layers-text"
-                        >All layers on/off</span
-                    >
+            <widget-container
+                icon="layers"
+                title=""
+                .collapsed="${this.collapsed}"
+                .hideCloseButton="${true}"
+                .compactMode="${true}"
+                .reverseHeader="${true}"
+            >
+                <div class="container">
+                    <div class="layer-manager-rows">
+                        <div class="row">
+                            <input
+                                type="checkbox"
+                                class="visibility-checkbox"
+                                .checked="${this.visible}"
+                                @change="${this.onLayerVisibilityChanged}"
+                            />
+                            <span class="legacy-text all-layers-text"
+                                >All layers on/off</span
+                            >
+                        </div>
+                        <slot></slot>
+                    </div>
                 </div>
-                <slot></slot>
-            </div>
+            </widget-container>
         `;
     }
 

--- a/js/layer_manager_row.ts
+++ b/js/layer_manager_row.ts
@@ -31,7 +31,6 @@ export class LayerManagerRow extends LitWidget<
                 align-items: center;
                 display: flex;
                 gap: 4px;
-                height: 30px;
             }
 
             .layer-name {
@@ -43,9 +42,9 @@ export class LayerManagerRow extends LitWidget<
             }
 
             .row-button {
-                font-size: 14px;
-                height: 26px;
-                width: 26px;
+                font-size: 16px;
+                height: 28px;
+                width: 28px;
             }
 
             .layer-opacity-slider {
@@ -100,8 +99,12 @@ export class LayerManagerRow extends LitWidget<
                 flex-grow: 1;
             }
 
+            .confirm-deletion-container {
+                margin-top: 4px;
+            }
+
             .confirm-deletion-container button {
-                height: 26px;
+                height: 28px;
                 width: 70px;
             }
         `,

--- a/js/search_bar.ts
+++ b/js/search_bar.ts
@@ -136,7 +136,6 @@ export class SearchBar extends LitWidget<
                 icon="search"
                 title="Search"
                 .collapsed="${this.collapsed}"
-                .mode="${TabMode.ALWAYS_SHOW}"
                 .hideCloseButton="${true}"
                 .compactMode="${true}">
                 <tab-panel

--- a/js/toolbar.ts
+++ b/js/toolbar.ts
@@ -6,25 +6,18 @@ import { classMap } from "lit/directives/class-map.js";
 import { legacyStyles } from "./ipywidgets_styles";
 import { LitWidget } from "./lit_widget";
 import { materialStyles } from "./styles";
-import { Alignment } from "./tab_panel";
 import { loadFonts, updateChildren } from "./utils";
 
 import "./container";
 import "./tab_panel";
 
-
 export interface ToolbarModel {
-    accessory_widgets: any;
     main_tools: any;
-    extra_tools: any
+    extra_tools: any;
     expanded: boolean;
-    tab_index: number;
 }
 
-export class Toolbar extends LitWidget<
-    ToolbarModel,
-    Toolbar
-> {
+export class Toolbar extends LitWidget<ToolbarModel, Toolbar> {
     static get componentName() {
         return `toolbar-panel`;
     }
@@ -39,10 +32,6 @@ export class Toolbar extends LitWidget<
 
             .expanded {
                 display: block; !important
-            }
-
-            .tools-container {
-                padding: 4px;
             }
 
             slot[name="extra-tools"] {
@@ -62,46 +51,35 @@ export class Toolbar extends LitWidget<
 
     modelNameToViewName(): Map<keyof ToolbarModel, keyof Toolbar | null> {
         return new Map([
-            ["accessory_widgets", null],
             ["main_tools", null],
             ["extra_tools", null],
             ["expanded", "expanded"],
-            ["tab_index", "tab_index"],
         ]);
     }
 
     @property()
     expanded: boolean = false;
 
-    @property()
-    tab_index: number = 0;
-
     render() {
         return html`
             <widget-container
-                .collapsed="${false}"
+                icon="build"
+                title=""
+                .collapsed="${true}"
                 .hideCloseButton=${true}
-                .noHeader="${true}">
-                <tab-panel
-                    .index="${this.tab_index}"
-                    .tabs=${[{ icon: "layers", width: 74 }, { icon: "build" }]}
-                    .alignment="${Alignment.RIGHT}"
-                    @tab-changed=${(e: CustomEvent<number>) => {
-                    this.tab_index = e.detail;
-                }}>
-                    <div class="accessory-container">
-                        <slot name="accessory-widget"></slot>
-                    </div>
-                    <div class="tools-container">
-                        <slot name="main-tools"></slot>
-                        <slot
-                            name="extra-tools"
-                            class="${classMap({
-                    hide: !this.expanded,
-                    expanded: this.expanded,
-                })}"></slot>
-                    </div>
-                </tab-panel>
+                .compactMode="${true}"
+                .reverseHeader="${true}"
+            >
+                <div class="tools-container">
+                    <slot name="main-tools"></slot>
+                    <slot
+                        name="extra-tools"
+                        class="${classMap({
+                            hide: !this.expanded,
+                            expanded: this.expanded,
+                        })}"
+                    ></slot>
+                </div>
             </widget-container>
         `;
     }
@@ -117,15 +95,6 @@ async function render({ model, el }: RenderProps<ToolbarModel>) {
     const manager = <Toolbar>document.createElement(Toolbar.componentName);
     manager.model = model;
     el.appendChild(manager);
-
-    const accessoryWidgetEl = document.createElement("div");
-    accessoryWidgetEl.slot = "accessory-widget";
-    manager.appendChild(accessoryWidgetEl);
-
-    updateChildren(accessoryWidgetEl, model, "accessory_widgets");
-    model.on("change:accessory_widgets", () => {
-        updateChildren(accessoryWidgetEl, model, "accessory_widgets");
-    });
 
     const mainToolsEl = document.createElement("div");
     mainToolsEl.slot = "main-tools";

--- a/js/utils.ts
+++ b/js/utils.ts
@@ -26,11 +26,11 @@ export function loadFonts() {
 export async function updateChildren(
     container: HTMLElement,
     model: AnyModel<any>,
-    property = "children",
+    property = "children"
 ) {
     let children = model.get(property);
     if (!Array.isArray(children)) {
-        children = [children]
+        children = [children];
     }
     const child_models = await unpackModels(children, model.widget_manager);
     const child_views = await Promise.all(
@@ -62,7 +62,8 @@ export function renderSelect(
     value: string,
     callback: (event: Event) => void
 ): TemplateResult {
-    const newOptions = options.map((option) => {
+    const emptyOptions = options.length === 0;
+    const newOptions = (emptyOptions ? ["---"] : options).map((option) => {
         const isObject = typeof option === "object";
         const optValue = `${isObject ? option.value : option}`;
         const optLabel = `${isObject ? option.label : option}`;
@@ -73,6 +74,12 @@ export function renderSelect(
         `;
     });
     return html`
-        <select class="legacy-select" @change="${callback}">${newOptions}</select>
+        <select
+            class="legacy-select"
+            @change="${callback}"
+            ?disabled=${emptyOptions}
+        >
+            ${newOptions}
+        </select>
     `;
 }

--- a/tests/basemap_selector.spec.ts
+++ b/tests/basemap_selector.spec.ts
@@ -56,8 +56,13 @@ describe("<basemap-selector>", () => {
     it("selects the default provider appropriately.", () => {
         const selects = selector.shadowRoot?.querySelectorAll("select")!;
         const providerSelect = selects[0];
+        const resourceSelect = selects[1];
+
+        expect(selects.length).toBe(2); // Resource select should display "---".
         expect(providerSelect.value).toBe("DEFAULT");
-        expect(selects.length).toBe(1); // Resource select shouldn't be visible.
+        expect(selector.provider).toBe("DEFAULT");
+        expect(resourceSelect.value).toBe("---");
+        expect(selector.resource).toBe("");
     });
 
     it("setting the provider and resource on model updates the view.", async () => {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -44,11 +44,13 @@ class TestMap(unittest.TestCase):
         controls = self.core_map.controls
         self.assertEqual(len(controls), 7)
         self.assertIsInstance(controls[0], ipyleaflet.WidgetControl)
-        self.assertIsInstance(controls[1], ipyleaflet.ZoomControl)
-        self.assertIsInstance(controls[2], ipyleaflet.FullScreenControl)
-        self.assertIsInstance(controls[3], core.MapDrawControl)
-        self.assertIsInstance(controls[4], ipyleaflet.ScaleControl)
-        self.assertIsInstance(controls[5].widget, toolbar.Toolbar)
+        self.assertIsInstance(controls[0].widget.children[0], map_widgets.LayerManager)
+        self.assertIsInstance(controls[0].widget.children[1], toolbar.Toolbar)
+        self.assertIsInstance(controls[1].widget, map_widgets.SearchBar)
+        self.assertIsInstance(controls[2], ipyleaflet.ZoomControl)
+        self.assertIsInstance(controls[3], ipyleaflet.FullScreenControl)
+        self.assertIsInstance(controls[4], core.MapDrawControl)
+        self.assertIsInstance(controls[5], ipyleaflet.ScaleControl)
         self.assertIsInstance(controls[6], ipyleaflet.AttributionControl)
 
     def test_set_center(self):
@@ -113,8 +115,9 @@ class TestMap(unittest.TestCase):
 
         self.core_map.add("scale_control", position="topleft", metric=False)
 
-        self.assertEqual(len(self.core_map.controls), 1)
-        control = self.core_map.controls[0]
+        # Scale control and top right layout box.
+        self.assertEqual(len(self.core_map.controls), 2)
+        control = self.core_map.controls[1]
         self.assertIsInstance(control, ipyleaflet.ScaleControl)
         self.assertEqual(control.position, "topleft")
         self.assertEqual(control.metric, False)
@@ -125,8 +128,9 @@ class TestMap(unittest.TestCase):
 
         self.core_map.add(ipyleaflet.ScaleControl(position="topleft", metric=False))
 
-        self.assertEqual(len(self.core_map.controls), 1)
-        control = self.core_map.controls[0]
+        # Scale control and top right layout box.
+        self.assertEqual(len(self.core_map.controls), 2)
+        control = self.core_map.controls[1]
         self.assertIsInstance(control, ipyleaflet.ScaleControl)
         self.assertEqual(control.position, "topleft")
         self.assertEqual(control.metric, False)
@@ -134,14 +138,14 @@ class TestMap(unittest.TestCase):
     def test_add_duplicate_basic_widget(self):
         """Tests adding a duplicate widget to the map."""
         self.assertEqual(len(self.core_map.controls), 7)
-        self.assertIsInstance(self.core_map.controls[0], ipyleaflet.WidgetControl)
-        self.assertEqual(self.core_map.controls[0].position, "topleft")
+        self.assertIsInstance(self.core_map.controls[1], ipyleaflet.WidgetControl)
+        self.assertEqual(self.core_map.controls[1].position, "topleft")
 
         self.core_map.add("zoom_control", position="bottomright")
 
         self.assertEqual(len(self.core_map.controls), 7)
-        self.assertIsInstance(self.core_map.controls[0], ipyleaflet.WidgetControl)
-        self.assertEqual(self.core_map.controls[0].position, "topleft")
+        self.assertIsInstance(self.core_map.controls[1], ipyleaflet.WidgetControl)
+        self.assertEqual(self.core_map.controls[1].position, "topleft")
 
     def test_add_toolbar(self):
         """Tests adding the toolbar widget."""
@@ -149,15 +153,10 @@ class TestMap(unittest.TestCase):
 
         self.core_map.add("toolbar", position="bottomright")
 
-        self.assertEqual(len(self.core_map.controls), 1)
-        toolbar_control = self.core_map.controls[0].widget
+        # Toolbar and top right layout box.
+        self.assertEqual(len(self.core_map.controls), 2)
+        toolbar_control = self.core_map.controls[1].widget
 
-        # Layer manager is selected and open by default.
-        self.assertEqual(toolbar_control.tab_index, 0)
-        layer_button = toolbar_control.accessory_widgets[0]
-        self.assertIsInstance(layer_button, map_widgets.LayerManager)
-
-        toolbar_control.tab_index = 1
         self.assertEqual(len(toolbar_control.main_tools), 3)
         self.assertEqual(toolbar_control.main_tools[0].tooltip_text, "Basemap selector")
         self.assertEqual(toolbar_control.main_tools[1].tooltip_text, "Inspector")
@@ -169,7 +168,8 @@ class TestMap(unittest.TestCase):
         self._clear_default_widgets()
         self.core_map.add("draw_control", position="topleft")
 
-        self.assertEqual(len(self.core_map.controls), 1)
+        # Draw control and top right layout box.
+        self.assertEqual(len(self.core_map.controls), 2)
         self.assertIsInstance(self.core_map.get_draw_control(), core.MapDrawControl)
 
     def test_add_basemap_selector(self):
@@ -178,7 +178,8 @@ class TestMap(unittest.TestCase):
 
         self.core_map.add("basemap_selector")
 
-        self.assertEqual(len(self.core_map.controls), 1)
+        # Basemap selector and top right layout box.
+        self.assertEqual(len(self.core_map.controls), 2)
 
 
 @patch.object(ee, "FeatureCollection", fake_ee.FeatureCollection)

--- a/tests/test_toolbar.py
+++ b/tests/test_toolbar.py
@@ -30,7 +30,6 @@ class TestToolbar(unittest.TestCase):
             callback=self.dummy_callback,
             reset=True,
         )
-        self.accessory_widgets = [ipywidgets.Text()]
         return super().setUp()
 
     def tearDown(self) -> None:
@@ -45,21 +44,21 @@ class TestToolbar(unittest.TestCase):
 
     def test_no_tools_throws(self):
         map = geemap.Map(ee_initialize=False)
-        self.assertRaises(ValueError, Toolbar, map, [], [], self.accessory_widgets)
+        self.assertRaises(ValueError, Toolbar, map, [], [])
 
     def test_only_main_tools_exist_if_no_extra_tools(self):
         map = geemap.Map(ee_initialize=False)
-        toolbar = Toolbar(map, [self.item], [], self.accessory_widgets)
+        toolbar = Toolbar(map, [self.item], [])
         self.assertNotIn(toolbar.toggle_widget, toolbar.main_tools)
 
     def test_all_tools_and_toggle_exist_if_extra_tools(self):
         map = geemap.Map(ee_initialize=False)
-        toolbar = Toolbar(map, [self.item], [self.reset_item], self.accessory_widgets)
+        toolbar = Toolbar(map, [self.item], [self.reset_item])
         self.assertIsNotNone(toolbar.toggle_widget)
 
     def test_toggle_expands_and_collapses(self):
         map = geemap.Map(ee_initialize=False)
-        toolbar = Toolbar(map, [self.item], [self.reset_item], self.accessory_widgets)
+        toolbar = Toolbar(map, [self.item], [self.reset_item])
         self.assertIsNotNone(toolbar.toggle_widget)
         toggle = toolbar.toggle_widget
         self.assertEqual(toggle.icon, "add")
@@ -84,7 +83,7 @@ class TestToolbar(unittest.TestCase):
 
     def test_triggers_callbacks(self):
         map = geemap.Map(ee_initialize=False)
-        toolbar = Toolbar(map, [self.item, self.reset_item], [], self.accessory_widgets)
+        toolbar = Toolbar(map, [self.item, self.reset_item], [])
         self.assertIsNone(self.last_called_with_selected)
         self.assertIsNone(self.last_called_item)
 
@@ -122,7 +121,7 @@ class TestToolbar(unittest.TestCase):
             icon="info", tooltip="dummy item", callback=callback, reset=False
         )
         map_fake = fake_map.FakeMap()
-        toolbar = Toolbar(map_fake, [item], [], self.accessory_widgets)
+        toolbar = Toolbar(map_fake, [item], [])
         toolbar.main_tools[0].active = True
         self.assertEqual(1, widget.selected_count)
         self.assertEqual(0, widget.cleanup_count)


### PR DESCRIPTION
**Changes:**

- Separate LayerManager from Toolbar. There are several implications:
  - a new "top right layout box" was created to layout the widgets horizontally (we can generalize the logic later),
  - the container `ipyleaflet.WidgetControl` now has `transparent_bg=True` with the background set by the widget container to prevent a background over the entire "top right layout box", and
  - added a reverse header mode on the container for panels that open down and to the left.

<img width="150" alt="Screenshot 2025-01-12 at 3 13 01 PM" src="https://github.com/user-attachments/assets/2ee25394-f376-4be7-b853-9765986e8422" /> <img width="150" alt="Screenshot 2025-01-12 at 3 13 12 PM" src="https://github.com/user-attachments/assets/cc3bfd86-4cf6-4f1b-b263-502c683be629" /> <img width="150" alt="Screenshot 2025-01-12 at 3 13 09 PM" src="https://github.com/user-attachments/assets/c4e24363-9a04-4a64-92bf-09b481239f15" /> <img width="150" alt="Screenshot 2025-01-12 at 3 13 04 PM" src="https://github.com/user-attachments/assets/767a6fcd-a94a-41b6-864c-d1f2e0edc140" />

- Keep the basemap selector resource select field visible when not needed, and fill with "---".

<img width="256" alt="Screenshot 2025-01-12 at 3 16 33 PM" src="https://github.com/user-attachments/assets/4cfa7daa-6645-41d9-a416-f62b389c78a8" /> <img width="256" alt="Screenshot 2025-01-12 at 3 16 43 PM" src="https://github.com/user-attachments/assets/5c5ebd63-e2bf-487e-9fb3-27fe814bda80" />

- Other UI tweaks, such as using the correct icon on the inspector and padding around the container header items.

<img width="306" alt="Screenshot 2025-01-12 at 3 18 24 PM" src="https://github.com/user-attachments/assets/d837a5b2-6332-40ff-a2b7-397829b4eba2" /> <img width="306" alt="Screenshot 2025-01-12 at 3 18 53 PM" src="https://github.com/user-attachments/assets/68f4ffd6-93c5-483c-b8d4-e09715423201" />