### PR TITLE
bugfix:  Fix geemap.deck.Map.add_ee_layer to recognize Layer kwargs

### DIFF
--- a/geemap/deck.py
+++ b/geemap/deck.py
@@ -102,9 +102,7 @@ class Map(pdk.Deck):
         except Exception as e:
             raise Exception(e)
 
-    def add_ee_layer(
-        self, ee_object, vis_params={}, name=None, **kwargs
-    ):
+    def add_ee_layer(self, ee_object, vis_params={}, name=None, **kwargs):
         """Adds a given EE object to the map as a layer.
 
         Args:

--- a/geemap/deck.py
+++ b/geemap/deck.py
@@ -84,6 +84,8 @@ class Map(pdk.Deck):
 
         Args:
             layer (pydeck.Layer): A pydeck Layer object.
+            layer_name (str, optional): Sets the layer 'id' for the pydeck Layer object.
+            **kwargs (Any): Additional keyword arguments for the pydeck Layer object.
         """
 
         try:
@@ -94,14 +96,14 @@ class Map(pdk.Deck):
                         "resourceUri": "https://cdn.jsdelivr.net/gh/giswqs/pydeck_myTileLayer@master/dist/bundle.js",
                     }
                 ]
-                layer = pdk.Layer("MyTileLayer", layer, id=layer_name)
+                layer = pdk.Layer("MyTileLayer", layer, id=layer_name, **kwargs)
 
             self.layers.append(layer)
         except Exception as e:
             raise Exception(e)
 
     def add_ee_layer(
-        self, ee_object, vis_params={}, name=None, shown=True, opacity=1.0, **kwargs
+        self, ee_object, vis_params={}, name=None, **kwargs
     ):
         """Adds a given EE object to the map as a layer.
 
@@ -109,8 +111,7 @@ class Map(pdk.Deck):
             ee_object (Collection|Feature|Image|MapId): The object to add to the map.
             vis_params (dict, optional): The visualization parameters. Defaults to {}.
             name (str, optional): The name of the layer. Defaults to 'Layer N'.
-            shown (bool, optional): A flag indicating whether the layer should be on by default. Defaults to True.
-            opacity (float, optional): The layer's opacity represented as a number between 0 and 1. Defaults to 1.
+            **kwargs (Any): Additional keyword arguments for the pydeck Layer object.
         """
         import ee
         from box import Box

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+
+"""Tests for `geemap.deck` package."""
+
+import unittest
+from unittest.mock import patch
+
+from box import Box
+import ee
+import geemap.deck as gmd
+from tests import fake_ee
+
+try:
+    import pydeck as pdk
+
+except ImportError:
+    raise ImportError("pydeck needs to be installed to use this module.")
+
+
+FAKE_URL = "http://fake.apis.com/v1/projects/fake-project/maps/XXX/tiles/{z}/{x}/{y}"
+
+
+@patch.object(ee, "Image", fake_ee.Image, spec=True)
+class TestMap(unittest.TestCase):
+    """Tests for `geemap.deck.Map` class."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.view_state = pdk.ViewState()
+        self.ee_object = fake_ee.Image()
+
+    def tearDown(self):
+        """Tear down test fixtures, if any."""
+
+    def test_ee_layer_opacity(self):
+        """Verify the opacity parameter is processed."""
+        m = gmd.Map(ee_initialize=False, initial_view_state=self.view_state)
+        with patch.object(ee.Image, "getMapId", autospec=True) as mock_get_map_id:
+            mock_get_map_id.return_value = {
+                "tile_fetcher": Box({"url_format": FAKE_URL})
+            }
+            m.add_ee_layer(self.ee_object, vis_params={}, opacity=0.5)
+
+        self.assertEquals(len(m.layers), 1)
+        layer = m.layers[0]
+
+        self.assertIsInstance(layer, pdk.Layer)
+        self.assertEqual(layer.opacity, 0.5)


### PR DESCRIPTION
Fix for issue #2213 : opacity kwarg not being recognized

This allows all Earth Engine object layers in `geemap.deck` to support any of the `deck.gl` [Layer properties](https://deck.gl/docs/api-reference/core/layer#properties).  

Demo of fix: see [this notebook](https://colab.research.google.com/drive/1isMKsgvbSqTl13UwKVon7QhLsIYwbp_0?resourcekey=0-UDBOJS5r16uadDAUYsivqg&usp=sharing) which shows both `opacity` and `visiblw` now being recognized.

Changes include:
* Removed explicit `opacity` and `shown` kwargs from `geemap.deck.Map.add_ee_layer` which were not being used.  Use `kwargs` instead.
* Fixed `geemap.deck.Map.add_layer` to propagate kwargs to `pydeck.Layer` constructor
* Unit test module (`test_deck.py`) for `geemap.deck`