### PR TITLE
Bump eerepr to v0.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "bqplot",
     "colour",
     "earthengine-api>=1.0.0",
-    "eerepr>=0.0.5",
+    "eerepr>=0.1.0",
     "folium>=0.17.0",
     "geocoder",
     "ipyevents",


### PR DESCRIPTION
Pin eerepr >v0.1.0. Release notes are [here](https://github.com/aazuspan/eerepr/releases/tag/v0.1.0).

There was a security vulnerability with `v0.5.0`.

v0.1.0 must be manually initialized, which we are [already doing](https://github.com/gee-community/geemap/commit/4be9dfeb2bcbacc807d000b3b0aac205ce6e598e).

Once this change is merged in, I'll cherrypick it into the last release branch and create a new release.