### PR TITLE
Add max_error parameter to center_object method

### DIFF
--- a/geemap/core.py
+++ b/geemap/core.py
@@ -456,15 +456,19 @@ class MapInterface:
         raise NotImplementedError()
 
     def center_object(
-        self, ee_object: ee.ComputedObject, zoom: Optional[int] = None
+        self,
+        ee_object: ee.ComputedObject,
+        zoom: Optional[int] = None,
+        max_error: float = 0.001,
     ) -> None:
         """Centers the map view on a given object.
 
         Args:
             ee_object (ee.ComputedObject): The Earth Engine object to center on.
             zoom (Optional[int]): Zoom level to set. Defaults to None.
+            max_error (float): The maximum error for the geometry. Defaults to 0.001.
         """
-        del ee_object, zoom  # Unused.
+        del ee_object, zoom, max_error  # Unused.
         raise NotImplementedError()
 
     def get_scale(self) -> float:
@@ -846,20 +850,25 @@ class Map(ipyleaflet.Map, MapInterface):
             ) from exc
 
     def center_object(
-        self, ee_object: ee.ComputedObject, zoom: Optional[int] = None
+        self,
+        ee_object: ee.ComputedObject,
+        zoom: Optional[int] = None,
+        max_error: float = 0.001,
     ) -> None:
         """Centers the map view on a given object.
 
         Args:
             ee_object (ee.ComputedObject): The Earth Engine object to center on.
             zoom (Optional[int]): Zoom level to set. Defaults to None.
+            max_error (float): The maximum error for the geometry. Defaults to 0.001.
         """
-        max_error = 0.001
         geometry = self._get_geometry(ee_object, max_error).transform(
             maxError=max_error
         )
         if zoom is None:
-            coordinates = geometry.bounds(max_error).getInfo()["coordinates"][0]
+            coordinates = geometry.bounds(maxError=max_error).getInfo()["coordinates"][
+                0
+            ]
             x_vals = [c[0] for c in coordinates]
             y_vals = [c[1] for c in coordinates]
             self.fit_bounds([[min(y_vals), min(x_vals)], [max(y_vals), max(x_vals)]])

--- a/geemap/foliumap.py
+++ b/geemap/foliumap.py
@@ -321,21 +321,20 @@ class Map(folium.Map):
         bounds = gdf.total_bounds
         self.zoom_to_bounds(bounds)
 
-    def center_object(self, ee_object, zoom=None):
+    def center_object(self, ee_object, zoom=None, max_error=0.001):
         """Centers the map view on a given object.
 
         Args:
             ee_object (Element|Geometry): An Earth Engine object to center on a geometry, image or feature.
             zoom (int, optional): The zoom level, from 1 to 24. Defaults to None.
+            max_error (float, optional): The maximum error for the geometry. Defaults to 0.001.
         """
-
-        maxError = 0.001
         if isinstance(ee_object, ee.Geometry):
-            geometry = ee_object.transform(maxError=maxError)
+            geometry = ee_object.transform(maxError=max_error)
         else:
             try:
-                geometry = ee_object.geometry(maxError=maxError).transform(
-                    maxError=maxError
+                geometry = ee_object.geometry(maxError=max_error).transform(
+                    maxError=max_error
                 )
             except Exception:
                 raise Exception(
@@ -346,7 +345,9 @@ class Map(folium.Map):
             if not isinstance(zoom, int):
                 raise Exception("Zoom must be an integer.")
             else:
-                centroid = geometry.centroid(maxError=maxError).getInfo()["coordinates"]
+                centroid = geometry.centroid(maxError=max_error).getInfo()[
+                    "coordinates"
+                ]
                 lat = centroid[1]
                 lon = centroid[0]
                 self.set_center(lon, lat, zoom)
@@ -355,7 +356,9 @@ class Map(folium.Map):
                     arc_zoom_to_extent(lon, lat, lon, lat)
 
         else:
-            coordinates = geometry.bounds(maxError).getInfo()["coordinates"][0]
+            coordinates = geometry.bounds(maxError=max_error).getInfo()["coordinates"][
+                0
+            ]
             x = [c[0] for c in coordinates]
             y = [c[1] for c in coordinates]
             xmin = min(x)

--- a/geemap/geemap.py
+++ b/geemap/geemap.py
@@ -474,7 +474,10 @@ class Map(core.Map):
     setCenter = set_center
 
     def center_object(
-        self, ee_object: Union[ee.Element, ee.Geometry], zoom: Optional[int] = None
+        self,
+        ee_object: Union[ee.Element, ee.Geometry],
+        zoom: Optional[int] = None,
+        max_error: float = 0.001,
     ) -> None:
         """Centers the map view on a given object.
 
@@ -482,8 +485,9 @@ class Map(core.Map):
             ee_object (Union[ee.Element, ee.Geometry]): An Earth Engine object to
                 center on a geometry, image or feature.
             zoom (Optional[int], optional): The zoom level, from 1 to 24. Defaults to None.
+            max_error (float, optional): The maximum error for the geometry. Defaults to 0.001.
         """
-        super().center_object(ee_object, zoom)
+        super().center_object(ee_object=ee_object, zoom=zoom, max_error=max_error)
         if is_arcpy():
             bds = self.bounds
             arc_zoom_to_extent(bds[0][1], bds[0][0], bds[1][1], bds[1][0])


### PR DESCRIPTION
This pull request adds a `max_error` parameter to the `center_object` methods. The parameter allows users to specify the maximum error tolerance when computing geometry bounds and centroids. 

In case the parameter is not specified, the method doesn't change its behavior

### Changes

- Added max_error parameter (defaulting to 0.001) to the `center_object` method signature in:
  - geemap/core.py
  - geemap/foliumap.py
  - geemap/geemap.py

- Updated method documentation to describe the new parameter
- Fixed variable naming consistency (replacing maxError with max_error in function parameters)

### Why

This change provides users with more control over the precision vs. performance tradeoff when centering the map on Earth Engine objects. A higher `max_error` value can improve performance for complex and big geometries, while a lower value provides more precise centering.

