### PR TITLE
Deprecate IPython.core.display

### DIFF
--- a/geemap/toolbar.py
+++ b/geemap/toolbar.py
@@ -20,7 +20,7 @@ import ipywidgets as widgets
 import traitlets
 
 from ipyfilechooser import FileChooser
-from IPython.core.display import display
+from IPython.display import display
 from typing import Any, Callable, Optional
 
 from .common import *


### PR DESCRIPTION
`IPython.core.display ` has been deprecated. We should update it to `IPython.display ` 

![image](https://github.com/user-attachments/assets/586beb6d-ba7e-47cd-bc51-b8123e5dea0c)
