### PR TITLE
Fix `get_bounds` param name

### DIFF
--- a/geemap/geemap.py
+++ b/geemap/geemap.py
@@ -1287,7 +1287,7 @@ class Map(core.Map):
         Returns:
             list | dict: A list in the format [west, south, east, north] in degrees.
         """
-        return super().get_bounds(as_geo_json=asGeoJSON)
+        return super().get_bounds(as_geojson=asGeoJSON)
 
     def add_cog_layer(
         self,

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -14,7 +14,7 @@ mkdocs-material>=9.1.3
 mkdocs-pdf-export-plugin
 mkdocstrings
 mkdocstrings-crystal
-mkdocstrings-python-legacy
+mkdocstrings-python
 nbconvert
 nbformat
 pip


### PR DESCRIPTION
The `get_bounds` method of the `Map` class within the `core` module (parent) expects `as_geojson`: https://github.com/gee-community/geemap/blob/6f17eba218ffa40a89a9803cb83c3d47ff6b032b/geemap/core.py#L782.

## Before fix

```
m = geemap.Map()
m
m.get_bounds()
```

```
TypeError                                 Traceback (most recent call last)
[<ipython-input-4-8e42ba9c9602>](https://localhost:8080/#) in <cell line: 0>()
      1 m = geemap.Map()
      2 m
----> 3 m.get_bounds()

[/usr/local/lib/python3.11/dist-packages/geemap/geemap.py](https://localhost:8080/#) in get_bounds(self, asGeoJSON)
   1290             list | dict: A list in the format [west, south, east, north] in degrees.
   1291         """
-> 1292         return super().get_bounds(as_geo_json=asGeoJSON)
   1293 
   1294     def add_cog_layer(

TypeError: Map.get_bounds() got an unexpected keyword argument 'as_geo_json'
```

## After fix

```
[-171.21093750000003, -71.96538769913128, 171.5625, 71.9653876991313]
```