### PR TITLE
Fix: Handle empty map layers in basemap selector and replacement

### DIFF
--- a/geemap/core.py
+++ b/geemap/core.py
@@ -1084,25 +1084,27 @@ class Map(ipyleaflet.Map, MapInterface):
         if self._basemap_selector:
             return
 
-        basemap_names = kwargs.pop(
-            "basemaps", list(self._available_basemaps.keys()))
+        basemap_names = kwargs.pop("basemaps", list(self._available_basemaps.keys()))
 
         default_value_for_selector = None
         if self.layers:
-            first_layer_name = getattr(self.layers[0], 'name', '')
+            first_layer_name = getattr(self.layers[0], "name", "")
             if first_layer_name:
                 default_value_for_selector = self._get_preferred_basemap_name(
-                    first_layer_name)
+                    first_layer_name
+                )
             elif self._available_basemaps:
                 default_value_for_selector = self._get_preferred_basemap_name(
-                    next(iter(self._available_basemaps.keys())))
+                    next(iter(self._available_basemaps.keys()))
+                )
             else:
                 default_value_for_selector = "DEFAULT"
 
         elif self._available_basemaps:
             first_available_key = next(iter(self._available_basemaps.keys()))
             default_value_for_selector = self._get_preferred_basemap_name(
-                first_available_key)
+                first_available_key
+            )
         else:
             default_value_for_selector = "DEFAULT"
 

--- a/geemap/core.py
+++ b/geemap/core.py
@@ -1084,10 +1084,29 @@ class Map(ipyleaflet.Map, MapInterface):
         if self._basemap_selector:
             return
 
-        basemap_names = kwargs.pop("basemaps", list(self._available_basemaps.keys()))
-        value = kwargs.pop(
-            "value", self._get_preferred_basemap_name(self.layers[0].name)
-        )
+        basemap_names = kwargs.pop(
+            "basemaps", list(self._available_basemaps.keys()))
+
+        default_value_for_selector = None
+        if self.layers:
+            first_layer_name = getattr(self.layers[0], 'name', '')
+            if first_layer_name:
+                default_value_for_selector = self._get_preferred_basemap_name(
+                    first_layer_name)
+            elif self._available_basemaps:
+                default_value_for_selector = self._get_preferred_basemap_name(
+                    next(iter(self._available_basemaps.keys())))
+            else:
+                default_value_for_selector = "DEFAULT"
+
+        elif self._available_basemaps:
+            first_available_key = next(iter(self._available_basemaps.keys()))
+            default_value_for_selector = self._get_preferred_basemap_name(
+                first_available_key)
+        else:
+            default_value_for_selector = "DEFAULT"
+
+        value = kwargs.pop("value", default_value_for_selector)
         basemap = map_widgets.BasemapSelector(basemap_names, value, **kwargs)
         basemap.on_close = lambda: self.remove("basemap_selector")
         basemap.on_basemap_changed = self._replace_basemap
@@ -1419,8 +1438,11 @@ class Map(ipyleaflet.Map, MapInterface):
             max_zoom=basemap.get("max_zoom", 24),
             attribution=basemap.get("attribution", None),
         )
-        # substitute_layer is broken when the map has a single layer.
-        if len(self.layers) == 1:
+        if not self.layers:
+            self.add_layer(new_layer)
+        elif len(self.layers) == 1:
+            # TODO check if this quirk/bug is still present:
+            # substitute_layer is broken when the map has a single layer.
             self.clear_layers()
             self.add_layer(new_layer)
         else:


### PR DESCRIPTION
Fixes #2248

Before this fix, if there are no layers present in the layer manager the call to `self.layers[0]` fails. This PR adds logic to check for layers and falls back to a default layer name in the basemap selector widget if none exist.