### PR TITLE
deck.py and geemap.py: Use fiona directly to load the KML driver.

### DIFF
--- a/geemap/deck.py
+++ b/geemap/deck.py
@@ -314,6 +314,7 @@ class Map(pdk.Deck):
 
         try:
             import geopandas as gpd
+            import fiona
 
             if not filename.startswith("http"):
                 filename = os.path.abspath(filename)
@@ -321,7 +322,7 @@ class Map(pdk.Deck):
                     filename = "zip://" + filename
 
             if filename.endswith(".kml"):
-                gpd.io.file.fiona.drvsupport.supported_drivers["KML"] = "rw"
+                fiona.drvsupport.supported_drivers["KML"] = "rw"
                 gdf = gpd.read_file(filename, driver="KML")
             else:
                 gdf = gpd.read_file(filename)

--- a/geemap/geemap.py
+++ b/geemap/geemap.py
@@ -4133,6 +4133,7 @@ class Map(core.Map):
         ext = os.path.splitext(filename)[1].lower()
         if ext == ".kml":
             import fiona
+
             fiona.drvsupport.supported_drivers["KML"] = "rw"
             gdf = gpd.read_file(filename, driver="KML", **kwargs)
         else:

--- a/geemap/geemap.py
+++ b/geemap/geemap.py
@@ -4132,7 +4132,8 @@ class Map(core.Map):
             filename = os.path.abspath(filename)
         ext = os.path.splitext(filename)[1].lower()
         if ext == ".kml":
-            gpd.io.file.fiona.drvsupport.supported_drivers["KML"] = "rw"
+            import fiona
+            fiona.drvsupport.supported_drivers["KML"] = "rw"
             gdf = gpd.read_file(filename, driver="KML", **kwargs)
         else:
             gdf = gpd.read_file(filename, **kwargs)


### PR DESCRIPTION
This is needed for geopandas 0.11.1.