### PR TITLE
Replace color dependency with matplotlib.colors

### DIFF
--- a/geemap/common.py
+++ b/geemap/common.py
@@ -3454,7 +3454,7 @@ def create_colorbar(
     import decimal
 
     # import io
-    from colour import Color
+    from matplotlib import colors
     from PIL import Image, ImageDraw, ImageFont
 
     warnings.simplefilter("ignore")
@@ -3483,7 +3483,7 @@ def create_colorbar(
 
     n_colors = len(palette)
     decimal_places = 2
-    rgb_colors = [Color(check_color(c)).rgb for c in palette]
+    rgb_colors = [colors.to_rgb(c) for c in palette]
     keys = [
         round(c, decimal_places)
         for c in list(float_range(0, 1.0001, 1.0 / (n_colors - 1)))

--- a/geemap/coreutils.py
+++ b/geemap/coreutils.py
@@ -368,44 +368,50 @@ def in_colab_shell() -> bool:
     return "google.colab" in sys.modules
 
 
-def check_color(in_color: Union[str, Tuple[int, int, int]]) -> str:
+def check_color(in_color: Union[str, Tuple, List]) -> str:
     """Checks the input color and returns the corresponding hex color code.
 
     Args:
-        in_color (Union[str, Tuple[int, int, int]]): It can be a string (e.g.,
-            'red', '#ffff00', 'ffff00', 'ff0') or RGB tuple (e.g., (255, 127, 0)).
+        in_color (str or tuple or list): It can be a string (e.g., 'red', '#ffff00', 'ffff00', 'ff0') or RGB tuple/list (e.g., (255, 127, 0)).
 
     Returns:
         str: A hex color code.
     """
-    import colour
+    from matplotlib import colors
 
     out_color = "#000000"  # default black color
-    if isinstance(in_color, tuple) and len(in_color) == 3:
+    # Handle RGB tuple or list
+    if isinstance(in_color, (tuple, list)) and len(in_color) == 3:
         # rescale color if necessary
         if all(isinstance(item, int) for item in in_color):
+            # Ensure values are floats between 0 and 1 for to_hex
             in_color = [c / 255.0 for c in in_color]
-
-        return colour.Color(rgb=tuple(in_color)).hex_l
-
-    else:
-        # try to guess the color system
         try:
-            return colour.Color(in_color).hex_l
-
-        except Exception as e:
-            pass
-
-        # try again by adding an extra # (GEE handle hex codes without #)
-        try:
-            return colour.Color(f"#{in_color}").hex_l
-
-        except Exception as e:
+            return colors.to_hex(in_color)
+        except ValueError:
             print(
-                f"The provided color ({in_color}) is invalid. Using the default black color."
+                f"The provided RGB color ({in_color}) is invalid. Using the default black color."
             )
-            print(e)
+            return out_color
 
+    # Handle string color input
+    elif isinstance(in_color, str):
+        try:
+            # Try converting directly (handles color names and hex with #)
+            return colors.to_hex(in_color)
+        except ValueError:
+            try:
+                # Try again by adding an extra # (handles hex without #)
+                return colors.to_hex(f"#{in_color}")
+            except ValueError:
+                print(
+                    f"The provided color string ({in_color}) is invalid. Using the default black color."
+                )
+                return out_color
+    else:
+        print(
+            f"The provided color type ({type(in_color)}) is invalid. Using the default black color."
+        )
         return out_color
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ classifiers = [
 dependencies = [
     "anywidget",
     "bqplot",
-    "colour",
     "earthengine-api>=1.0.0",
     "eerepr>=0.1.0",
     "folium>=0.17.0",


### PR DESCRIPTION
Fix #2262

The [colour](https://github.com/vaab/colour) dependency has not been updated for 8 years. It does not support Python 3.12+. The PR replaces it with matplotlib.colors. 