### PR TITLE
astral-sh/setup-uv: Set to always use latest.

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -23,7 +23,7 @@ jobs:
             - name: Install uv
               uses: astral-sh/setup-uv@v6
               with:
-                  version: "0.4.16"
+                  version: "latest"
                   # enable-cache: true
 
             - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
             - name: Install uv
               uses: astral-sh/setup-uv@v6
               with:
-                  version: "0.4.16"
+                  version: "latest"
                   # enable-cache: true
 
             - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/installation.yml
+++ b/.github/workflows/installation.yml
@@ -20,7 +20,7 @@ jobs:
             - name: Install uv
               uses: astral-sh/setup-uv@v6
               with:
-                  version: "0.4.16"
+                  version: "latest"
                   enable-cache: true
 
             - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -24,7 +24,7 @@ jobs:
             - name: Install uv
               uses: astral-sh/setup-uv@v6
               with:
-                  version: "0.4.16"
+                  version: "latest"
                   enable-cache: true
 
             - name: Set up Python ${{ matrix.config.py }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -24,7 +24,7 @@ jobs:
             - name: Install uv
               uses: astral-sh/setup-uv@v6
               with:
-                  version: "0.4.16"
+                  version: "latest"
                   enable-cache: true
 
             - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,7 +25,7 @@ jobs:
             - name: Install uv
               uses: astral-sh/setup-uv@v6
               with:
-                  version: "0.4.16"
+                  version: "latest"
                   enable-cache: true
 
             - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
We should avoid pinning unless there is a specific issue.

https://github.com/astral-sh/setup-uv?tab=readme-ov-file#install-the-latest-version

We could also just let it flow through to the default, but let's start with a more explicit callout