### PR TITLE
Fix remaining bugs in the redesigned widgets

### DIFF
--- a/js/layer_manager.ts
+++ b/js/layer_manager.ts
@@ -73,8 +73,11 @@ export class LayerManager extends LitWidget<LayerManagerModel, LayerManager> {
                                 .checked="${this.visible}"
                                 @change="${this.onLayerVisibilityChanged}"
                             />
-                            <span class="legacy-text all-layers-text"
-                                >All layers on/off</span
+                            <span
+                                class="legacy-text all-layers-text"
+                                @click="${this.onLayerVisibilityChanged}"
+                            >
+                                All layers on/off</span
                             >
                         </div>
                         <slot></slot>
@@ -84,9 +87,8 @@ export class LayerManager extends LitWidget<LayerManagerModel, LayerManager> {
         `;
     }
 
-    private onLayerVisibilityChanged(event: Event): void {
-        const target = event.target as HTMLInputElement;
-        this.visible = target.checked;
+    private onLayerVisibilityChanged(_event: Event): void {
+        this.visible = !this.visible;
     }
 }
 

--- a/js/raster_layer_editor.ts
+++ b/js/raster_layer_editor.ts
@@ -78,6 +78,9 @@ export class RasterLayerEditor extends LitElement {
     @query("legend-customization") legendCustomization?: LegendCustomization;
     @queryAll("#band-selection select") bandSelects!: NodeListOf<HTMLInputElement>;
 
+    @query("#min") private minInput!: HTMLInputElement;
+    @query("#max") private maxInput!: HTMLInputElement;
+
     override connectedCallback() {
         super.connectedCallback();
         this.colorModel =
@@ -141,6 +144,7 @@ export class RasterLayerEditor extends LitElement {
                         id="min"
                         name="min"
                         .value="${this.minValue ?? "Loading..."}"
+                        @keydown="${this.onInputKeyDown}"
                         @change="${this.onMinTextChanged}"
                         ?disabled="${this.minAndMaxValuesLocked}"
                     />
@@ -151,6 +155,7 @@ export class RasterLayerEditor extends LitElement {
                         id="max"
                         name="max"
                         .value="${this.maxValue ?? "Loading..."}"
+                        @keydown="${this.onInputKeyDown}"
                         @change="${this.onMaxTextChanged}"
                         ?disabled="${this.minAndMaxValuesLocked}"
                     />
@@ -296,12 +301,16 @@ export class RasterLayerEditor extends LitElement {
         this.gamma = (event.target as HTMLInputElement).valueAsNumber;
     }
 
-    private onMinTextChanged(event: Event): void {
-        this.minValue = (event.target as HTMLInputElement).valueAsNumber;
+    private onInputKeyDown(event: KeyboardEvent): void {
+        event.stopPropagation();  // Prevent the event from bubbling up to the document.
     }
 
-    private onMaxTextChanged(event: Event): void {
-        this.maxValue = (event.target as HTMLInputElement).valueAsNumber;
+    private onMinTextChanged(_event: Event): void {
+        this.minValue = +this.minInput.value;  // Convert input string to number.
+    }
+
+    private onMaxTextChanged(_event: Event): void {
+        this.maxValue = +this.maxInput.value;  // Convert input string to number.
     }
 
     private calculateBandStats(): void {


### PR DESCRIPTION
Fixes 3 bugs: 
- Sometimes keyboard events would propagate up to the document and it could trigger keyboard shortcuts in Jupyter Lab.
- The min and max values are set to NaN when changing the inputs via the keyboard.
- Clicking on the "All layers on/off" text in the layer manager wouldn't trigger the checkbox.
