### PR TITLE
Add missing data folder in the source distribution

### DIFF
--- a/geemap/__init__.py
+++ b/geemap/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Qiusheng Wu"""
 __email__ = "giswqs@gmail.com"
-__version__ = "0.35.1"
+__version__ = "0.36.4"
 
 import os
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geemap"
-version = "0.35.1"
+version = "0.36.4"
 description = "A Python package for interactive mapping using Google Earth Engine and ipyleaflet"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -149,7 +149,7 @@ exclude = ["docs*"]
 universal = true
 
 [tool.bumpversion]
-current_version = "0.35.1"
+current_version = "0.36.4"
 commit = true
 tag = true
 
@@ -174,7 +174,10 @@ features = ["dev"]
 
 [tool.hatch.build]
 only-packages = true
-artifacts = ["geemap/static/*"]
+artifacts = [
+    "geemap/static/*",
+    "geemap/data/**/*",
+]
 
 [tool.hatch.build.hooks.jupyter-builder]
 build-function = "hatch_jupyter_builder.npm_builder"


### PR DESCRIPTION
Fix #2302 

Add the missing `geemap/data` folder in the source distribution, which contains template files for legend, fonts, etc.