### PR TITLE
pyproject.toml: Add setuptools to deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,5 +203,8 @@ dependencies = ["hatch-jupyter-builder>=0.5.0"]
 npm = "npm"
 build_cmd = "build"
 
+[tool.uv.extra-build-dependencies]
+backends = ["setuptools"]
+
 [project.urls]
 Homepage = "https://github.com/gee-community/geemap"


### PR DESCRIPTION
```
 Downloaded gradio
  × Failed to download and build `keplergl==0.3.7`
  ├─▶ Failed to install requirements from `build-system.requires`
  ├─▶ Failed to build `pyarrow==16.0.0`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit
      status: 1)
      [stderr]
      Traceback (most recent call last):
        File "<string>", line 14, in <module>
          requires = get_requires_for_build({})
        File
      "/home/runner/work/_temp/setup-uv-cache/builds-v0/.tmp1nGktH/lib/python3.13/site-packages/setuptools/build_meta.py",
      line 333, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File
      "/home/runner/work/_temp/setup-uv-cache/builds-v0/.tmp1nGktH/lib/python3.13/site-packages/setuptools/build_meta.py",
      line 301, in _get_build_requires
          self.run_setup()
          ~~~~~~~~~~~~~~^^
        File
      "/home/runner/work/_temp/setup-uv-cache/builds-v0/.tmp1nGktH/lib/python3.13/site-packages/setuptools/build_meta.py",
      line 520, in run_setup
          super().run_setup(setup_script=setup_script)
          ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File
      "/home/runner/work/_temp/setup-uv-cache/builds-v0/.tmp1nGktH/lib/python3.13/site-packages/setuptools/build_meta.py",
      line 317, in run_setup
          exec(code, locals())
          ~~~~^^^^^^^^^^^^^^^^
        File "<string>", line 34, in <module>
      ModuleNotFoundError: No module named 'pkg_resources'
      hint: This error likely indicates that `pyarrow@16.0.0` depends on
      `pkg_resources`, but doesn't declare it as a build dependency. If
      `pyarrow` is a first-party package, consider adding `pkg_resources`
      to its `build-system.requires`. Otherwise, either add it to your
      `pyproject.toml` under:
      [tool.uv.extra-build-dependencies]
```