### PR TITLE
fix(map_widgets): Pop consumed kwargs before passing **kwargs to ColorbarBase

### DIFF
--- a/geemap/map_widgets.py
+++ b/geemap/map_widgets.py
@@ -162,8 +162,11 @@ class Colorbar(ipywidgets.Output):
         if not isinstance(vis_params, dict):
             raise TypeError("The vis_params must be a dictionary.")
 
-        if isinstance(kwargs.get("colors"), (list, tuple)):
-            vis_params["palette"] = list(kwargs["colors"])
+        colors = kwargs.pop("colors", None)
+        if isinstance(colors, (list, tuple)):
+            vis_params["palette"] = list(colors)
+
+        caption = kwargs.pop("caption", None)
 
         width, height = self._get_dimensions(orientation, kwargs)
 
@@ -216,7 +219,7 @@ class Colorbar(ipywidgets.Output):
             **kwargs,
         )
 
-        label = label or vis_params.get("bands") or kwargs.pop("caption", None)
+        label = label or vis_params.get("bands") or caption
         if label:
             cb.set_label(label, fontsize=font_size)
 
@@ -252,8 +255,8 @@ class Colorbar(ipywidgets.Output):
         if orientation in default_dims:
             default = default_dims[orientation]
             return (
-                kwargs.get("width", default[0]),
-                kwargs.get("height", default[1]),
+                kwargs.pop("width", default[0]),
+                kwargs.pop("height", default[1]),
             )
         raise ValueError(
             f"orientation must be one of [{', '.join(default_dims.keys())}]."

--- a/tests/test_map_widgets.py
+++ b/tests/test_map_widgets.py
@@ -202,7 +202,6 @@ class TestColorbar(unittest.TestCase):
             alpha=1,
             cmap=self.listed_colormap,
             orientation="horizontal",
-            colors=self.TEST_COLORS,
         )
 
     def test_colorbar_min_max(self):
@@ -227,7 +226,6 @@ class TestColorbar(unittest.TestCase):
             alpha=0.5,
             cmap=mock.ANY,
             orientation=mock.ANY,
-            colors=mock.ANY,
         )
 
     def test_colorbar_alpha(self):
@@ -238,7 +236,6 @@ class TestColorbar(unittest.TestCase):
             alpha=0.5,
             cmap=mock.ANY,
             orientation=mock.ANY,
-            colors=mock.ANY,
         )
 
     def test_colorbar_invalid_alpha(self):


### PR DESCRIPTION
``colors, caption, width, height`` are ``Colorbar``-specific parameters that were read with ``.get()`` instead of  ``.pop()``, causing them to leak into the ``**kwargs`` spread on the ``ColorbarBase``call. ``ColorbarBase`` never accepted these arguments, the bug was hidden since day one by a non-autospecced mock that silently swallowed any kwargs.