### PR TITLE
Avoid mutable default arguments (#2501)

### DIFF
--- a/geemap/chart.py
+++ b/geemap/chart.py
@@ -1552,7 +1552,7 @@ def image_histogram(
     min_bucket_width: float,
     max_raw: int,
     max_pixels: int,
-    reducer_args: dict[str, Any] = {},
+    reducer_args: dict[str, Any] | None = None,
     **kwargs: dict[str, Any],
 ) -> bq.Figure:
     """Creates a histogram for each band of the specified image within the given region.
@@ -1576,6 +1576,9 @@ def image_histogram(
     Returns:
         The bqplot figure containing the histograms.
     """
+    if reducer_args is None:
+        reducer_args = {}
+
     # Calculate the histogram data.
     histogram = image.reduceRegion(
         reducer=ee.Reducer.histogram(

--- a/geemap/common.py
+++ b/geemap/common.py
@@ -3857,7 +3857,7 @@ def search_ee_data(
     regex: bool = False,
     source: str = "ee",
     types=None,
-    keys: list[str] = ["id", "provider", "tags", "title"],
+    keys: list[str] | None = None,
 ):
     """Searches Earth Engine data catalog.
 
@@ -3875,6 +3875,9 @@ def search_ee_data(
     Returns:
         list: Returns a list of assets.
     """
+    if keys is None:
+        keys = ["id", "provider", "tags", "title"]
+
     if isinstance(keywords, str):
         keywords = keywords.split(" ")
 
@@ -12457,7 +12460,7 @@ def download_ee_image_tiles_parallel(
     scale_offset: bool = False,
     unmask_value: float | None = None,
     column: str | None = None,
-    job_args: dict[str, Any] = {"n_jobs": -1},
+    job_args: dict[str, Any] | None = None,
     ee_init: bool = True,
     project_id: str | None = None,
     **kwargs,
@@ -12499,6 +12502,9 @@ def download_ee_image_tiles_parallel(
 
     """
     import joblib
+
+    if job_args is None:
+        job_args = {"n_jobs": -1}
 
     start = time.time()
 

--- a/geemap/deck.py
+++ b/geemap/deck.py
@@ -131,8 +131,7 @@ class Map(pdk.Deck):
     def add_ee_layer(
         self,
         ee_object,
-        # TODO(schwehr): Do not use a mutable object as the default.
-        vis_params: dict[Any, Any] = {},
+        vis_params: dict[Any, Any] | None = None,
         name: str | None = None,
         **kwargs,
     ):
@@ -140,7 +139,7 @@ class Map(pdk.Deck):
 
         Args:
             ee_object (Collection|Feature|Image|MapId): The object to add to the map.
-            vis_params: The visualization parameters. Defaults to {}.
+            vis_params: The visualization parameters. Defaults to None.
             name: The name of the layer. Defaults to 'Layer N'.
             **kwargs: Additional keyword arguments for the pydeck Layer object.
         """

--- a/geemap/plotlymap.py
+++ b/geemap/plotlymap.py
@@ -419,7 +419,7 @@ class Map(go.FigureWidget):
     def add_ee_layer(
         self,
         ee_object,
-        vis_params={},
+        vis_params=None,
         name: str | None = None,
         shown: bool = True,
         opacity: float = 1.0,
@@ -429,7 +429,7 @@ class Map(go.FigureWidget):
 
         Args:
             ee_object (Collection|Feature|Image|MapId): The object to add to the map.
-            vis_params (dict, optional): The visualization parameters. Defaults to {}.
+            vis_params (dict, optional): The visualization parameters. Defaults to None.
             name: The name of the layer. Defaults to 'Layer N'.
             shown: A flag indicating whether the layer should be on by default.
             opacity: The layer's opacity represented as a number between 0 and 1.


### PR DESCRIPTION
Fixes part of #2501.

Per the [Google Python style guide](https://google.github.io/styleguide/pyguide.html#2124-decision),
mutable objects should not be used as default argument values. This PR fixes
a focused set of occurrences by defaulting to `None` and initializing the
mutable value inside the function body:

- `chart.py`: `image_histogram` (`reducer_args`)
- `common.py`: `search_ee_data` (`keys`), `download_ee_image_tiles_parallel` (`job_args`)
- `deck.py`: `Map.add_ee_layer` (`vis_params`) — also removes the now-resolved `TODO`
- `plotlymap.py`: `Map.add_ee_layer` (`vis_params`)

`deck.py` and `plotlymap.py` already guarded against `None` internally, so
those are signature/docstring updates only. Behavior is preserved.

**Verification:** `black --check` passes and all changed files compile.

**Scope note:** This is a focused first pass. There are more occurrences
(mainly in `maplibregl.py` and `timelapse.py`) that I'm happy to address in
a follow-up PR if you'd like — kept this one small for easy review.
