### PR TITLE
Stop using deprecated matplotlib get_cmap (#2499)

### DIFF
--- a/geemap/cartoee.py
+++ b/geemap/cartoee.py
@@ -23,7 +23,7 @@ import ee
 import matplotlib as mpl
 import matplotlib.patches as patches
 import matplotlib.pyplot as plt
-from matplotlib import cm, colors
+from matplotlib import colors
 from matplotlib import font_manager as mfonts
 from matplotlib.lines import Line2D
 import numpy as np
@@ -235,7 +235,7 @@ def build_palette(cmap: str, n: int = 256) -> list[str]:
         colormap = mpl.colormaps[cmap].resampled(n)
     else:
         # For older matplotlib versions
-        colormap = cm.get_cmap(cmap, n)
+        colormap = plt.get_cmap(cmap, n)
 
     return [colors.rgb2hex(colormap(i / (n - 1) if n > 1 else 0)[:3]) for i in range(n)]
 

--- a/geemap/common.py
+++ b/geemap/common.py
@@ -11919,10 +11919,7 @@ def classify(
 
     if cmap is None:
         cmap = "Blues"
-    try:
-        cmap = plt.get_cmap(cmap, k)
-    except:
-        cmap = plt.cm.get_cmap(cmap, k)
+    cmap = plt.get_cmap(cmap, k)
     if colors is None:
         colors = [mpl.colors.rgb2hex(cmap(i))[1:] for i in range(cmap.N)]
         colors = ["#" + i for i in colors]
@@ -12676,10 +12673,7 @@ def get_palette_colors(
         n_class: The number of colors. Defaults to None.
         hashtag: Whether to return a list of hex colors. Defaults to False.
     """
-    try:
-        cmap = plt.get_cmap(cmap_name, n_class)
-    except:
-        cmap = plt.cm.get_cmap(cmap_name, n_class)
+    cmap = plt.get_cmap(cmap_name, n_class)
     colors = [mpl.colors.rgb2hex(cmap(i))[1:] for i in range(cmap.N)]
     if hashtag:
         colors = ["#" + i for i in colors]

--- a/geemap/toolbar.py
+++ b/geemap/toolbar.py
@@ -2548,10 +2548,7 @@ def time_slider(m: geemap.Map | None = None):
                 if selected != "Any":
                     n_class = int(classes.value)
 
-                try:
-                    colors = plt.get_cmap(colormap.value, n_class)
-                except Exception:
-                    colors = plt.cm.get_cmap(colormap.value, n_class)
+                colors = plt.get_cmap(colormap.value, n_class)
                 cmap_colors = [
                     mpl.colors.rgb2hex(colors(i))[1:] for i in range(colors.N)
                 ]
@@ -2635,10 +2632,7 @@ def time_slider(m: geemap.Map | None = None):
             if classes.value != "Any":
                 n_class = int(classes.value)
 
-            try:
-                colors = plt.get_cmap(colormap.value, n_class)
-            except Exception:
-                colors = plt.cm.get_cmap(colormap.value, n_class)
+            colors = plt.get_cmap(colormap.value, n_class)
             cmap_colors = [mpl.colors.rgb2hex(colors(i))[1:] for i in range(colors.N)]
 
             _, ax = plt.subplots(figsize=(6, 0.4))


### PR DESCRIPTION
Fixes the matplotlib part of #2499.

`matplotlib.cm.get_cmap()` / `plt.cm.get_cmap()` were deprecated in
matplotlib 3.7 and **removed in 3.9**. Several call sites used it as a
`try/except` fallback where the `try` branch already used the supported
`plt.get_cmap(name, lut)`. Since matplotlib is unpinned, those fallback
branches would themselves fail on current matplotlib.

## Changes
- `common.py`: `classify()`, `get_palette_colors()` — drop the deprecated `try/except` fallbacks
- `toolbar.py`: `time_slider()` (×2) — drop the deprecated `try/except` fallbacks
- `cartoee.py`: `build_palette()` — use `plt.get_cmap` in the old-matplotlib branch and drop the now-unused `from matplotlib import cm`

Behavior is preserved on supported matplotlib versions.

**Verification:** `black --check` passes and all changed files compile.

**Scope note:** This covers the matplotlib part of #2499. I scanned for
deprecated **traitlets** calls and didn't find obvious ones, so that part
can be handled separately (happy to follow up if you point me at specifics).
