### PR TITLE
Don't crash map creation when Google Maps basemaps fail to load (#2701)

### DIFF
--- a/geemap/core.py
+++ b/geemap/core.py
@@ -1351,9 +1351,18 @@ class Map(ipyleaflet.Map, MapInterface):
         """
         tile_providers = list(basemaps.get_xyz_dict().values())
         if coreutils.get_google_maps_api_key():
-            tile_providers = tile_providers + list(
-                basemaps.get_google_map_tile_providers().values()
-            )
+            try:
+                tile_providers = tile_providers + list(
+                    basemaps.get_google_map_tile_providers().values()
+                )
+            except Exception as e:
+                logging.warning(
+                    "Unable to load Google Maps basemaps: %s. Continuing without "
+                    "them. Unset the GOOGLE_MAPS_API_KEY environment variable if "
+                    "your account or region does not support the Google Maps "
+                    "Tiles API.",
+                    e,
+                )
 
         ret_dict = {}
         for tile_info in tile_providers:

--- a/geemap/maplibregl.py
+++ b/geemap/maplibregl.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import glob
 import importlib.resources
+import logging
 import os
 import re
 from typing import Any
@@ -169,9 +170,18 @@ class Map(MapWidget):
         """Convert xyz tile services to a dictionary of basemaps."""
         tile_providers = list(get_xyz_dict().values())
         if coreutils.get_google_maps_api_key():
-            tile_providers = tile_providers + list(
-                get_google_map_tile_providers().values()
-            )
+            try:
+                tile_providers = tile_providers + list(
+                    get_google_map_tile_providers().values()
+                )
+            except Exception as e:
+                logging.warning(
+                    "Unable to load Google Maps basemaps: %s. Continuing without "
+                    "them. Unset the GOOGLE_MAPS_API_KEY environment variable if "
+                    "your account or region does not support the Google Maps "
+                    "Tiles API.",
+                    e,
+                )
 
         ret_dict = {}
         for tile_info in tile_providers:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -57,6 +57,31 @@ class TestMap(unittest.TestCase):
         self.assertIsInstance(controls[5], ipyleaflet.ScaleControl)
         self.assertIsInstance(controls[6], ipyleaflet.AttributionControl)
 
+    def test_available_basemaps_survive_google_maps_error(self):
+        """Map creation should not fail when Google Maps basemaps can't load.
+
+        Regression test for #2701: having GOOGLE_MAPS_API_KEY set should not
+        crash map creation if the account/region can't access the Tiles API.
+        """
+        with (
+            mock.patch.object(
+                core.coreutils, "get_google_maps_api_key", return_value="fake-key"
+            ),
+            mock.patch.object(
+                core.basemaps,
+                "get_google_map_tile_providers",
+                side_effect=RuntimeError("Error creating a Maps API session"),
+            ),
+        ):
+            with self.assertLogs(level="WARNING") as logged:
+                new_map = core.Map(ee_initialize=False)
+
+        # Standard basemaps are still available despite the Google Maps failure.
+        self.assertGreater(len(new_map._available_basemaps), 0)
+        self.assertTrue(
+            any("Unable to load Google Maps" in message for message in logged.output)
+        )
+
     def test_set_center(self):
         """Tests that `set_center` sets the center and zoom."""
         self.core_map.set_center(1, 2, 3)


### PR DESCRIPTION
Fixes #2701.

When `GOOGLE_MAPS_API_KEY` is set, geemap eagerly builds Google Maps tile
providers, which POST to the Maps Tiles `createSession` endpoint. For
accounts/regions without Tiles API access this returns **403** and raises a
`RuntimeError`, which propagated out of `_get_available_basemaps()` and
**crashed `Map()` creation** — even when the user never requested Google tiles
(the reporter hit this as an EU user).

## Fix
Wrap the Google-basemap loading in a `try/except` that logs a warning and
continues with the standard basemaps, in both `geemap.core.Map` and
`geemap.maplibregl.Map`.

## Testing
- Added a regression test (`test_available_basemaps_survive_google_maps_error`)
  that simulates the failure and asserts the map is still created with basemaps
  available and a warning emitted.
- **Ran locally:** `tests/test_core.py` → **20 passed**. `black --check` passes.

This implements the "display a warning when `GOOGLE_MAPS_API_KEY` is set but
authentication fails" option from the issue, without changing the public API.
