### PR TITLE
Refactor datasets.py to lazy-load DATA attribute on import 

### DIFF
--- a/geemap/datasets.py
+++ b/geemap/datasets.py
@@ -162,4 +162,19 @@ def get_metadata(asset_id: str, source: str = "ee") -> None:
     display(html_widget)
 
 
-DATA = box.Box(get_data_dict(), frozen_box=True)
+_DATA = None
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily loads module attributes to avoid network requests on import."""
+    global _DATA
+    if name == "DATA":
+        if _DATA is None:
+            _DATA = box.Box(get_data_dict(), frozen_box=True)
+        return _DATA
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
+
+def __dir__() -> list[str]:
+    """Returns the list of names in the module namespace."""
+    return list(globals().keys()) + ["DATA"]

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -21,12 +21,11 @@ class DatasetsTest(unittest.TestCase):
 
     def test_import_does_not_call_network(self):
         """Verifies that importing datasets does not make network calls."""
-        # Unload geemap.datasets to test a fresh import
-        if "geemap.datasets" in sys.modules:
-            del sys.modules["geemap.datasets"]
+        # Reset cached _DATA to simulate fresh state
+        datasets._DATA = None
 
         with mock.patch("urllib.request.urlopen") as mock_urlopen:
-            importlib.import_module("geemap.datasets")
+            importlib.reload(datasets)
             mock_urlopen.assert_not_called()
 
     def test_lazy_data_access(self):

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,7 +1,12 @@
 """Tests for `datasets` module."""
 
+import importlib
 import os
+import sys
 import unittest
+from unittest import mock
+
+import box
 
 from geemap import datasets
 
@@ -13,6 +18,44 @@ class DatasetsTest(unittest.TestCase):
         data_csv = datasets.get_data_csv()
         self.assertTrue(os.path.exists(data_csv))
         self.assertEqual(os.path.basename(data_csv), "ee_data_catalog.csv")
+
+    def test_import_does_not_call_network(self):
+        """Verifies that importing datasets does not make network calls."""
+        # Unload geemap.datasets to test a fresh import
+        if "geemap.datasets" in sys.modules:
+            del sys.modules["geemap.datasets"]
+
+        with mock.patch("urllib.request.urlopen") as mock_urlopen:
+            importlib.import_module("geemap.datasets")
+            mock_urlopen.assert_not_called()
+
+    def test_lazy_data_access(self):
+        """Verifies that accessing DATA lazily builds and caches the Box object."""
+        # Reset cached _DATA
+        datasets._DATA = None
+
+        fake_dict = {"test_dataset": "users/test/dataset"}
+        with mock.patch(
+            "geemap.datasets.get_data_dict", return_value=fake_dict
+        ) as mock_get_dict:
+            data = datasets.DATA
+            self.assertIsInstance(data, box.Box)
+            self.assertEqual(data.test_dataset, "users/test/dataset")
+            mock_get_dict.assert_called_once()
+
+            # Second access should return cached _DATA without calling get_data_dict again
+            data2 = datasets.DATA
+            self.assertIs(data, data2)
+            mock_get_dict.assert_called_once()
+
+    def test_getattr_invalid_attribute(self):
+        """Verifies that accessing an undefined attribute raises AttributeError."""
+        with self.assertRaises(AttributeError):
+            _ = datasets.NON_EXISTENT_ATTRIBUTE
+
+    def test_dir_contains_data(self):
+        """Verifies that dir(datasets) includes DATA."""
+        self.assertIn("DATA", dir(datasets))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
fixes #2395.

this praddresses an issue where importing `geemap.datasets` (or `geemap`) made unexpected network calls to fetch Earth Engine STAC catalog data. This happened because the module-level `DATA` attribute was being initialized immediately on import, causing import slowdowns and failures in offline environments,
to resolve this, `datasets.py` has been updated to use PEP 562 lazy loading. The network request and catalog instantiation are now deferred until `geemap.datasets.DATA` is explicitly accessed. This ensures that imports are fast and work completely offline while preserving full backwards compatibility.

## Changes Made
- Replaced the eager initialization of `DATA` in `geemap/datasets.py` with `__getattr__` and `__dir__` hooks.
- Cached the initialized `DATA` instance on first access to avoid duplicate network requests.
- Added comprehensive unit tests in `tests/test_datasets.py` to verify:
  - Importing `geemap.datasets` makes zero network calls.
  - Accessing `DATA` properly fetches and caches the catalog.
  - Namespace inspection via `dir()` includes `DATA`.
  - Accessing invalid attributes raises `AttributeError`.

## Checklist
- [x] My pull request includes tests covering the changes.
- [x] All existing and new tests pass.
- [x] No breaking API changes were introduced.
