### PR TITLE
Fix layer editor to apply vis_params (#2814)

### DIFF
--- a/geemap/map_widgets.py
+++ b/geemap/map_widgets.py
@@ -910,6 +910,7 @@ class LayerEditor(anywidget.AnyWidget):
     layer_type: traitlets.Unicode = traitlets.Unicode("").tag(sync=True)
     band_names: traitlets.List = traitlets.List([]).tag(sync=True)
     colormaps: traitlets.List = traitlets.List([]).tag(sync=True)
+    vis_params: traitlets.Dict = traitlets.Dict({}).tag(sync=True)
 
     # Child widgets in the container. Using a tuple here to force reassignment to update
     # the list. When a proper notifying-list trait exists, use that instead.
@@ -943,6 +944,7 @@ class LayerEditor(anywidget.AnyWidget):
             self._ee_layer = layer_dict["ee_layer"]
             self.layer_name = self._ee_layer.name
             self.colormaps = self._get_colormaps()
+            self.vis_params = layer_dict.get("vis_params") or {}
 
             if isinstance(self._ee_object, ee.FeatureCollection):
                 self.layer_type = LayerEditor.LayerType.VECTOR.value

--- a/js/layer_editor.ts
+++ b/js/layer_editor.ts
@@ -22,6 +22,8 @@ export interface LayerEditorModel {
     band_names: Array<string>;
     // Colormaps available to select.
     colormaps: Array<string>;
+    // Visualization parameters passed to the layer.
+    vis_params: Record<string, any>;
 }
 
 export class LayerEditor extends LitWidget<LayerEditorModel, LayerEditor> {
@@ -54,6 +56,7 @@ export class LayerEditor extends LitWidget<LayerEditorModel, LayerEditor> {
     @property({ type: String }) layerType: string = "";
     @property({ type: Array }) bandNames: Array<string> = [];
     @property({ type: Array }) colormaps: Array<string> = [];
+    @property({ type: Object }) visParams: Record<string, any> = {};
 
     @query("raster-layer-editor") rasterEditor?: RasterLayerEditor;
     @query("vector-layer-editor") vectorEditor?: VectorLayerEditor;
@@ -67,6 +70,7 @@ export class LayerEditor extends LitWidget<LayerEditorModel, LayerEditor> {
             ["layer_type", "layerType"],
             ["band_names", "bandNames"],
             ["colormaps", "colormaps"],
+            ["vis_params", "visParams"],
             ["children", null],
         ]);
     }
@@ -119,6 +123,7 @@ export class LayerEditor extends LitWidget<LayerEditorModel, LayerEditor> {
                 <raster-layer-editor
                     .bandNames="${this.bandNames}"
                     .colormaps="${this.colormaps}"
+                    .visParams="${this.visParams}"
                     @calculate-band-stats="${this.calculateBandStats}"
                     @calculate-palette="${this.calculatePalette}"
                 >

--- a/js/raster_layer_editor.ts
+++ b/js/raster_layer_editor.ts
@@ -73,6 +73,10 @@ export class RasterLayerEditor extends LitElement {
     @property({ type: String }) colorRamp: string = ColorRamp.Gamma;
     @property({ type: Number }) gamma: number = 1.0;
     @property({ type: Array }) colormaps: Array<string> = [];
+    @property({ type: Object }) visParams: Record<string, any> = {};
+    @property({ type: String }) initialPalette: string = "";
+
+    private _hasVisBands = false;
 
     @query("palette-editor") paletteEditor?: PaletteEditor;
     @query("legend-customization") legendCustomization?: LegendCustomization;
@@ -83,8 +87,42 @@ export class RasterLayerEditor extends LitElement {
 
     override connectedCallback() {
         super.connectedCallback();
-        this.colorModel =
-            this.bandNames.length > 1 ? ColorModel.RGB : ColorModel.Gray;
+        const visParams = this.visParams || {};
+        const bands = Array.isArray(visParams.bands)
+            ? (visParams.bands as Array<string>)
+            : [];
+
+        if (bands.length === 1) {
+            this.colorModel = ColorModel.Gray;
+        } else if (bands.length >= 3) {
+            this.colorModel = ColorModel.RGB;
+        } else {
+            this.colorModel =
+                this.bandNames.length > 1 ? ColorModel.RGB : ColorModel.Gray;
+        }
+
+        if (bands.length > 0) {
+            this.selectedBands = bands.slice();
+            this._hasVisBands = true;
+        }
+
+        if (visParams.min !== undefined) {
+            this.minValue = visParams.min;
+        }
+        if (visParams.max !== undefined) {
+            this.maxValue = visParams.max;
+        }
+        if (visParams.gamma !== undefined) {
+            this.gamma = visParams.gamma;
+        }
+
+        if (Array.isArray(visParams.palette)) {
+            this.colorRamp = ColorRamp.Palette;
+            this.initialPalette = visParams.palette.join(", ");
+        } else if (typeof visParams.palette === "string") {
+            this.colorRamp = ColorRamp.Palette;
+            this.initialPalette = visParams.palette;
+        }
     }
 
     getVisualizationOptions(): any {
@@ -202,7 +240,10 @@ export class RasterLayerEditor extends LitElement {
             this.colorModel === ColorModel.Gray
         ) {
             return html`
-                <palette-editor .colormaps="${this.colormaps}">
+                <palette-editor
+                    .colormaps="${this.colormaps}"
+                    .palette="${this.initialPalette}"
+                >
                     <slot></slot>
                 </palette-editor>
             `;
@@ -343,7 +384,7 @@ export class RasterLayerEditor extends LitElement {
     override updated(changedProperties: PropertyValues<RasterLayerEditor>): void {
         super.updated(changedProperties);
 
-        if (changedProperties.has("colorModel")) {
+        if (changedProperties.has("colorModel") && !this._hasVisBands) {
             if (this.colorModel === ColorModel.Gray) {
                 this.selectedBands = [this.bandNames[0]];
             } else if (this.colorModel == ColorModel.RGB) {

--- a/tests/raster_layer_editor.spec.ts
+++ b/tests/raster_layer_editor.spec.ts
@@ -1,0 +1,67 @@
+import "../js/raster_layer_editor";
+import { RasterLayerEditor } from "../js/raster_layer_editor";
+
+describe("<raster-layer-editor>", () => {
+    let editor: RasterLayerEditor;
+
+    async function makeEditor(visParams: Record<string, any>) {
+        const element = document.createElement(
+            RasterLayerEditor.componentName
+        ) as RasterLayerEditor;
+        element.bandNames = [
+            "B1",
+            "B2",
+            "B3",
+            "B4",
+            "B5",
+            "B7",
+        ];
+        element.colormaps = ["Custom", "viridis"];
+        element.visParams = visParams;
+        document.body.appendChild(element);
+        await element.updateComplete;
+        return element;
+    }
+
+    afterEach(() => {
+        Array.from(document.querySelectorAll("raster-layer-editor")).forEach(
+            (el) => {
+                el.remove();
+            }
+        );
+    });
+
+    it("initializes bands, min, and max from vis_params", async () => {
+        editor = await makeEditor({
+            bands: ["B4", "B3", "B2"],
+            min: 20,
+            max: 200,
+            gamma: 1.5,
+        });
+
+        expect(editor.selectedBands).toEqual(["B4", "B3", "B2"]);
+        expect(editor.minValue).toBe(20);
+        expect(editor.maxValue).toBe(200);
+        expect(editor.gamma).toBe(1.5);
+
+        const minInput = editor.shadowRoot?.querySelector("#min") as HTMLInputElement;
+        const maxInput = editor.shadowRoot?.querySelector("#max") as HTMLInputElement;
+        expect(minInput.value).toBe("20");
+        expect(maxInput.value).toBe("200");
+    });
+
+    it("uses the palette from vis_params for single-band layers", async () => {
+        editor = await makeEditor({
+            min: 0,
+            max: 4000,
+            palette: ["006633", "E5FFCC", "662A00", "D8D8D8", "F5F5F5"],
+        });
+
+        expect(editor.minValue).toBe(0);
+        expect(editor.maxValue).toBe(4000);
+        expect(editor.colorRamp).toBe("palette");
+        expect(editor.initialPalette).toBe(
+            "006633, E5FFCC, 662A00, D8D8D8, F5F5F5"
+        );
+    });
+});

--- a/tests/test_map_widgets.py
+++ b/tests/test_map_widgets.py
@@ -794,11 +794,11 @@ class TestBasemapSelector(unittest.TestCase):
 class TestLayerEditor(unittest.TestCase):
     """Tests for the `LayerEditor` class in the `map_widgets` module."""
 
-    def _fake_layer_dict(self, ee_object):
+    def _fake_layer_dict(self, ee_object, vis_params=None):
         return {
             "ee_object": ee_object,
             "ee_layer": fake_map.FakeEeTileLayer(name="fake-ee-layer-name"),
-            "vis_params": {},
+            "vis_params": vis_params or {},
         }
 
     def setUp(self):
@@ -852,6 +852,19 @@ class TestLayerEditor(unittest.TestCase):
         self.assertEqual(widget.layer_type, "raster")
         self.assertEqual(widget.band_names, ["B1", "B2"])
         self.assertEqual(widget.colormaps, _get_colormaps())
+
+    def test_layer_editor_uses_vis_params(self):
+        """Tests that vis_params from the layer dict are applied to the widget."""
+        vis_params = {
+            "bands": ["B4", "B3", "B2"],
+            "min": 20,
+            "max": 200,
+            "gamma": 1.5,
+        }
+        widget = map_widgets.LayerEditor(
+            self._fake_map, self._fake_layer_dict(ee.Image(), vis_params)
+        )
+        self.assertEqual(widget.vis_params, vis_params)
 
     def test_layer_editor_handle_calculate_band_stats(self):
         """Tests that calculate band stats works."""


### PR DESCRIPTION
## Summary

Fixes #2814.

The layer settings dialog was always initializing from default values instead of the `vis_params` passed to `Map.addLayer()`. As a result, when opening the layer editor for a raster layer, the bands, min, max, gamma, and palette shown in the dialog did not match the layer's actual visualization parameters.

## Changes

- `geemap/map_widgets.py`: expose `vis_params` as a synced trait on `LayerEditor` and populate it from the layer metadata.
- `js/layer_editor.ts`: map `vis_params` into the widget model and pass it to `raster-layer-editor`.
- `js/raster_layer_editor.ts`: initialize bands, min, max, gamma, and palette from `vis_params` when the editor mounts.
- `tests/test_map_widgets.py`: add a regression test for the `vis_params` trait.
- `tests/raster_layer_editor.spec.ts`: add frontend tests covering RGB band selection + min/max/gamma and single-band palette initialization.

## Verification

- `uv run pytest tests/test_map_widgets.py` — 65 passed
- `npm test` — 20 passed
- `npm run typecheck` — passed
- `npm run build` — succeeded